### PR TITLE
feat: upgrade MiniMax default model to M3 (512K context, image input)

### DIFF
--- a/docs/windows-deploy.md
+++ b/docs/windows-deploy.md
@@ -197,7 +197,7 @@ Select CodingPlan Default Model:
   1) qwen3.5-plus  - Qwen 3.5 (Fastest)
   2) glm-5  - Zhipu GLM-5 (Recommended for coding)
   3) kimi-k2.5  - Moonshot Kimi K2.5
-  4) MiniMax-M2.5  - MiniMax M2.5
+  4) MiniMax-M3  - MiniMax M3
 
 Select model [1/2/3/4]:
 ```

--- a/docs/zh-cn/windows-deploy.md
+++ b/docs/zh-cn/windows-deploy.md
@@ -201,7 +201,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
   1) qwen3.5-plus  - 千问 3.5（速度最快）
   2) glm-5  - 智谱 GLM-5（编程推荐）
   3) kimi-k2.5  - Moonshot Kimi K2.5
-  4) MiniMax-M2.5  - MiniMax M2.5
+  4) MiniMax-M3  - MiniMax M3
 
 选择模型 [1/2/3/4]:
 ```

--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -390,7 +390,7 @@ func defaultModelSpec(modelName string) ModelSpec {
 		"deepseek-reasoner":      {256000, 128000, false, true},
 		"kimi-k2.5":              {256000, 128000, true, true},
 		"glm-5":                  {200000, 128000, false, true},
-		"MiniMax-M3":             {200000, 128000, false, true},
+		"MiniMax-M3":             {512000, 128000, true, true},
 		"MiniMax-M2.7":           {200000, 128000, false, true},
 		"MiniMax-M2.7-highspeed": {200000, 128000, false, true},
 	}

--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -138,7 +138,7 @@ func (g *Generator) GenerateOpenClawConfig(req WorkerConfigRequest) ([]byte, err
 				"model": map[string]interface{}{
 					"primary": "hiclaw-gateway/" + modelName,
 				},
-				"models":       g.allModelAliases(modelName),
+				"models":        g.allModelAliases(modelName),
 				"maxConcurrent": 4,
 				"subagents": map[string]interface{}{
 					"maxConcurrent": 8,
@@ -378,21 +378,21 @@ func defaultModelSpec(modelName string) ModelSpec {
 	}
 
 	presets := map[string]preset{
-		"gpt-5.3-codex":     {400000, 128000, true, true},
-		"gpt-5-mini":        {400000, 128000, true, true},
-		"gpt-5-nano":        {400000, 128000, true, true},
-		"claude-opus-4-6":   {1000000, 128000, true, true},
-		"claude-sonnet-4-6": {1000000, 64000, true, true},
-		"claude-haiku-4-5":  {200000, 64000, true, true},
-		"qwen3.6-plus":      {200000, 64000, true, true},
-		"qwen3.5-plus":      {200000, 64000, true, true},
-		"deepseek-chat":     {256000, 128000, false, true},
-		"deepseek-reasoner": {256000, 128000, false, true},
-		"kimi-k2.5":         {256000, 128000, true, true},
-		"glm-5":             {200000, 128000, false, true},
-		"MiniMax-M2.7":          {200000, 128000, false, true},
+		"gpt-5.3-codex":          {400000, 128000, true, true},
+		"gpt-5-mini":             {400000, 128000, true, true},
+		"gpt-5-nano":             {400000, 128000, true, true},
+		"claude-opus-4-6":        {1000000, 128000, true, true},
+		"claude-sonnet-4-6":      {1000000, 64000, true, true},
+		"claude-haiku-4-5":       {200000, 64000, true, true},
+		"qwen3.6-plus":           {200000, 64000, true, true},
+		"qwen3.5-plus":           {200000, 64000, true, true},
+		"deepseek-chat":          {256000, 128000, false, true},
+		"deepseek-reasoner":      {256000, 128000, false, true},
+		"kimi-k2.5":              {256000, 128000, true, true},
+		"glm-5":                  {200000, 128000, false, true},
+		"MiniMax-M3":             {200000, 128000, false, true},
+		"MiniMax-M2.7":           {200000, 128000, false, true},
 		"MiniMax-M2.7-highspeed": {200000, 128000, false, true},
-		"MiniMax-M2.5":          {200000, 128000, false, true},
 	}
 
 	p, found := presets[modelName]
@@ -453,7 +453,7 @@ func (g *Generator) allModelSpecs(selectedModel string) []ModelSpec {
 		"qwen3.6-plus", "qwen3.5-plus",
 		"deepseek-chat", "deepseek-reasoner",
 		"kimi-k2.5", "glm-5",
-		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5",
+		"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed",
 	}
 
 	specs := make([]ModelSpec, 0, len(allModels)+1)
@@ -477,7 +477,7 @@ func (g *Generator) allModelAliases(selectedModel string) map[string]interface{}
 		"qwen3.6-plus", "qwen3.5-plus",
 		"deepseek-chat", "deepseek-reasoner",
 		"kimi-k2.5", "glm-5",
-		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5",
+		"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed",
 	}
 
 	aliases := make(map[string]interface{})

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -320,7 +320,7 @@ $script:Messages = @{
     "llm.codingplan.model.qwen36plus" = @{ zh = "  1) qwen3.6-plus  - 千问 3.6（推荐）"; en = "  1) qwen3.6-plus  - Qwen 3.6 (recommended)" }
     "llm.codingplan.model.glm5" = @{ zh = "  2) glm-5  - 智谱 GLM-5（编程推荐）"; en = "  2) glm-5  - Zhipu GLM-5 (recommended for coding)" }
     "llm.codingplan.model.kimi" = @{ zh = "  3) kimi-k2.5  - Moonshot Kimi K2.5"; en = "  3) kimi-k2.5  - Moonshot Kimi K2.5" }
-    "llm.codingplan.model.minimax" = @{ zh = "  4) MiniMax-M2.5  - MiniMax M2.5"; en = "  4) MiniMax-M2.5  - MiniMax M2.5" }
+    "llm.codingplan.model.minimax" = @{ zh = "  4) MiniMax-M3  - MiniMax M3"; en = "  4) MiniMax-M3  - MiniMax M3" }
     "llm.codingplan.model.select" = @{ zh = "选择模型 [1/2/3/4]"; en = "Select model [1/2/3/4]" }
     "llm.provider.selected_tokenplan" = @{ zh = "  提供商: 阿里云通义 Token 套餐（兼容模式）"; en = "  Provider: Alibaba Cloud Token Plan (compatible mode)" }
     "llm.provider.selected_codingplan" = @{ zh = "  提供商: 阿里云通义 Token 套餐（alibaba-cloud）"; en = "  Provider: Qwen Cloud (international) (alibaba-cloud)" }
@@ -675,7 +675,7 @@ $script:KnownModels = @(
     "gpt-5.4", "gpt-5.3-codex", "gpt-5-mini", "gpt-5-nano",
     "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
     "qwen3.6-plus", "qwen3.5-plus", "deepseek-chat", "deepseek-reasoner",
-    "kimi-k2.5", "glm-5", "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5"
+    "kimi-k2.5", "glm-5", "MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"
 )
 
 function Test-KnownModel {
@@ -1786,7 +1786,7 @@ function Step-Llm {
                         "qwen3.6-plus" { "1" }
                         "glm-5"         { "2" }
                         "kimi-k2.5"     { "3" }
-                        "MiniMax-M2.5"  { "4" }
+                        "MiniMax-M3"    { "4" }
                         default         { "1" }
                     }
                     $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [${defaultModel}]"
@@ -1802,7 +1802,7 @@ function Step-Llm {
                     "^(1|qwen3\.6-plus)$"  { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                     "^(2|glm-5)$"          { $script:config.DEFAULT_MODEL = "glm-5" }
                     "^(3|kimi-k2\.5)$"     { $script:config.DEFAULT_MODEL = "kimi-k2.5" }
-                    "^(4|MiniMax-M2\.5)$"  { $script:config.DEFAULT_MODEL = "MiniMax-M2.5" }
+                    "^(4|MiniMax-M3)$"     { $script:config.DEFAULT_MODEL = "MiniMax-M3" }
                     default                { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                 }
                 Write-Log (Get-Msg "llm.provider.selected_codingplan")
@@ -1838,7 +1838,7 @@ function Step-Llm {
                             "qwen3.6-plus" { "1" }
                             "glm-5"         { "2" }
                             "kimi-k2.5"     { "3" }
-                            "MiniMax-M2.5"  { "4" }
+                            "MiniMax-M3"    { "4" }
                             default         { "1" }
                         }
                         $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [${defaultModel}]"
@@ -1854,7 +1854,7 @@ function Step-Llm {
                         "^(1|qwen3\.6-plus)$"  { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                         "^(2|glm-5)$"          { $script:config.DEFAULT_MODEL = "glm-5" }
                         "^(3|kimi-k2\.5)$"     { $script:config.DEFAULT_MODEL = "kimi-k2.5" }
-                        "^(4|MiniMax-M2\.5)$"  { $script:config.DEFAULT_MODEL = "MiniMax-M2.5" }
+                        "^(4|MiniMax-M3)$"     { $script:config.DEFAULT_MODEL = "MiniMax-M3" }
                         default                { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                     }
                     Write-Log (Get-Msg "llm.provider.selected_tokenplan")

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -431,8 +431,8 @@ msg() {
         "llm.codingplan.model.glm5.en") text="  2) glm-5  - Zhipu GLM-5 (recommended for coding)" ;;
         "llm.codingplan.model.kimi.zh") text="  3) kimi-k2.5  - Moonshot Kimi K2.5" ;;
         "llm.codingplan.model.kimi.en") text="  3) kimi-k2.5  - Moonshot Kimi K2.5" ;;
-        "llm.codingplan.model.minimax.zh") text="  4) MiniMax-M2.5  - MiniMax M2.5" ;;
-        "llm.codingplan.model.minimax.en") text="  4) MiniMax-M2.5  - MiniMax M2.5" ;;
+        "llm.codingplan.model.minimax.zh") text="  4) MiniMax-M3  - MiniMax M3" ;;
+        "llm.codingplan.model.minimax.en") text="  4) MiniMax-M3  - MiniMax M3" ;;
         "llm.codingplan.model.select.zh") text="选择模型 [1/2/3/4]" ;;
         "llm.codingplan.model.select.en") text="Select model [1/2/3/4]" ;;
         "llm.provider.selected_tokenplan.zh") text="  提供商: 阿里云通义 Token 套餐（兼容模式）" ;;
@@ -1075,7 +1075,7 @@ resolve_embedded_image() {
 # ============================================================
 # Known models list — used to detect custom models during install
 # ============================================================
-KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.6-plus qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5"
+KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.6-plus qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M3 MiniMax-M2.7 MiniMax-M2.7-highspeed"
 
 is_known_model() {
     local model="$1"
@@ -1914,7 +1914,7 @@ step_llm() {
                         qwen3.6-plus) _model_default="1" ;;
                         glm-5)        _model_default="2" ;;
                         kimi-k2.5)    _model_default="3" ;;
-                        MiniMax-M2.5) _model_default="4" ;;
+                        MiniMax-M3)   _model_default="4" ;;
                         *)            _model_default="1" ;;
                     esac
                     read -e -p "$(msg llm.codingplan.model.select) [${_model_default}]: " CODINGPLAN_MODEL_CHOICE
@@ -1931,7 +1931,7 @@ step_llm() {
                     1|qwen3.6-plus) HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                     2|glm-5)        HICLAW_DEFAULT_MODEL="glm-5" ;;
                     3|kimi-k2.5)    HICLAW_DEFAULT_MODEL="kimi-k2.5" ;;
-                    4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
+                    4|MiniMax-M3)   HICLAW_DEFAULT_MODEL="MiniMax-M3" ;;
                     *)              HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                 esac
                 log "$(msg llm.provider.selected_codingplan)"
@@ -1985,7 +1985,7 @@ step_llm() {
                                 qwen3.6-plus) _model_default="1" ;;
                                 glm-5)        _model_default="2" ;;
                                 kimi-k2.5)    _model_default="3" ;;
-                                MiniMax-M2.5) _model_default="4" ;;
+                                MiniMax-M3)   _model_default="4" ;;
                                 *)            _model_default="1" ;;
                             esac
                             read -e -p "$(msg llm.codingplan.model.select) [${_model_default}]: " CODINGPLAN_MODEL_CHOICE
@@ -2002,7 +2002,7 @@ step_llm() {
                             1|qwen3.6-plus) HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                             2|glm-5)        HICLAW_DEFAULT_MODEL="glm-5" ;;
                             3|kimi-k2.5)    HICLAW_DEFAULT_MODEL="kimi-k2.5" ;;
-                            4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
+                            4|MiniMax-M3)   HICLAW_DEFAULT_MODEL="MiniMax-M3" ;;
                             *)              HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                         esac
                         log "$(msg llm.provider.selected_tokenplan)"

--- a/manager/agent/skills/model-switch/SKILL.md
+++ b/manager/agent/skills/model-switch/SKILL.md
@@ -79,4 +79,5 @@ When the human admin requests switching to a model you don't recognize, you MUST
 | claude-haiku-4-5 | 200,000 | 64,000 |
 | qwen3.5-plus | 200,000 | 64,000 |
 | deepseek-chat / deepseek-reasoner / kimi-k2.5 | 256,000 | 128,000 |
-| glm-5 / MiniMax-M3 / MiniMax-M2.7 / MiniMax-M2.7-highspeed | 200,000 | 128,000 |
+| glm-5 / MiniMax-M2.7 / MiniMax-M2.7-highspeed | 200,000 | 128,000 |
+| MiniMax-M3 | 512,000 | 128,000 |

--- a/manager/agent/skills/model-switch/SKILL.md
+++ b/manager/agent/skills/model-switch/SKILL.md
@@ -79,4 +79,4 @@ When the human admin requests switching to a model you don't recognize, you MUST
 | claude-haiku-4-5 | 200,000 | 64,000 |
 | qwen3.5-plus | 200,000 | 64,000 |
 | deepseek-chat / deepseek-reasoner / kimi-k2.5 | 256,000 | 128,000 |
-| glm-5 / MiniMax-M2.7 / MiniMax-M2.7-highspeed / MiniMax-M2.5 | 200,000 | 128,000 |
+| glm-5 / MiniMax-M3 / MiniMax-M2.7 / MiniMax-M2.7-highspeed | 200,000 | 128,000 |

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -99,7 +99,7 @@ case "${MODEL_NAME}" in
         CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
-    glm-5|MiniMax-M2.7|MiniMax-M2.7-highspeed|MiniMax-M2.5)
+    glm-5|MiniMax-M3|MiniMax-M2.7|MiniMax-M2.7-highspeed)
         CTX=200000; MAX=128000 ;;
     *)
         CTX=150000; MAX=128000 ;;

--- a/manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl
+++ b/manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl
@@ -56,7 +56,7 @@
           { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 512000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
         ]

--- a/manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl
+++ b/manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl
@@ -56,9 +56,9 @@
           { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+          { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
         ]
       }
     }
@@ -84,9 +84,9 @@
         "hiclaw-gateway/deepseek-reasoner": { "alias": "deepseek-reasoner" },
         "hiclaw-gateway/kimi-k2.5":         { "alias": "kimi-k2.5" },
         "hiclaw-gateway/glm-5":             { "alias": "glm-5" },
+        "hiclaw-gateway/MiniMax-M3":        { "alias": "MiniMax-M3" },
         "hiclaw-gateway/MiniMax-M2.7":      { "alias": "MiniMax-M2.7" },
-        "hiclaw-gateway/MiniMax-M2.7-highspeed": { "alias": "MiniMax-M2.7-highspeed" },
-        "hiclaw-gateway/MiniMax-M2.5":      { "alias": "MiniMax-M2.5" }
+        "hiclaw-gateway/MiniMax-M2.7-highspeed": { "alias": "MiniMax-M2.7-highspeed" }
       },
       "maxConcurrent": 4,
       "subagents": {

--- a/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
+++ b/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
@@ -47,7 +47,7 @@ case "${MODEL_NAME}" in
         CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
-    glm-5|MiniMax-M2.7|MiniMax-M2.7-highspeed|MiniMax-M2.5)
+    glm-5|MiniMax-M3|MiniMax-M2.7|MiniMax-M2.7-highspeed)
         CTX=200000; MAX=128000 ;;
     *)
         CTX=150000; MAX=128000 ;;

--- a/manager/configs/known-models.json
+++ b/manager/configs/known-models.json
@@ -12,7 +12,7 @@
   { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
   { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-  { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+  { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 512000,  "maxTokens": 128000, "input": ["text", "image"] },
   { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
 ]

--- a/manager/configs/known-models.json
+++ b/manager/configs/known-models.json
@@ -12,7 +12,7 @@
   { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
   { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+  { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-  { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-  { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+  { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
 ]

--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -63,7 +63,7 @@
           { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 512000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
         ]

--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -63,9 +63,9 @@
           { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+          { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
         ]
       }
     }
@@ -91,9 +91,9 @@
         "hiclaw-gateway/deepseek-reasoner": { "alias": "deepseek-reasoner" },
         "hiclaw-gateway/kimi-k2.5":         { "alias": "kimi-k2.5" },
         "hiclaw-gateway/glm-5":             { "alias": "glm-5" },
+        "hiclaw-gateway/MiniMax-M3":        { "alias": "MiniMax-M3" },
         "hiclaw-gateway/MiniMax-M2.7":      { "alias": "MiniMax-M2.7" },
-        "hiclaw-gateway/MiniMax-M2.7-highspeed": { "alias": "MiniMax-M2.7-highspeed" },
-        "hiclaw-gateway/MiniMax-M2.5":      { "alias": "MiniMax-M2.5" }
+        "hiclaw-gateway/MiniMax-M2.7-highspeed": { "alias": "MiniMax-M2.7-highspeed" }
       },
       "maxConcurrent": 8,
       "subagents": {

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -638,7 +638,7 @@ case "${MODEL_NAME}" in
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         export MODEL_CONTEXT_WINDOW=256000 MODEL_MAX_TOKENS=128000 ;;
-    glm-5|MiniMax-M2.7|MiniMax-M2.7-highspeed|MiniMax-M2.5)
+    glm-5|MiniMax-M3|MiniMax-M2.7|MiniMax-M2.7-highspeed)
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=128000 ;;
     *)
         export MODEL_CONTEXT_WINDOW=150000 MODEL_MAX_TOKENS=128000 ;;


### PR DESCRIPTION
## Summary
Upgrade the MiniMax model configuration to make `MiniMax-M3` the primary MiniMax option, drop the deprecated `M2.5`, and keep `M2.7` / `M2.7-highspeed` as alternatives.

## Changes
- Add `MiniMax-M3` to the model selection list (512K context, 128K max output, image input supported)
- Place `MiniMax-M3` ahead of the older MiniMax variants and use it as the CodingPlan option 4 default in both installers
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` from active model lists (kept in v1.0.4 changelog as historical record)

## Affected files
- `manager/configs/known-models.json`, `manager/configs/manager-openclaw.json.tmpl`
- `manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl`
- `manager/agent/skills/worker-management/scripts/generate-worker-config.sh`
- `manager/agent/skills/model-switch/scripts/update-manager-model.sh` + `SKILL.md`
- `manager/scripts/init/start-manager-agent.sh`
- `hiclaw-controller/internal/agentconfig/generator.go` (`presets` map + `allModels` arrays — M3 set to 512K context with vision)
- `install/hiclaw-install.sh` + `install/hiclaw-install.ps1` (CodingPlan model menu)
- `docs/windows-deploy.md` + `docs/zh-cn/windows-deploy.md`

## Why
`MiniMax-M3` is the latest MiniMax model, offering a 512K context window, up to 128K output, and image input support (OpenAI-compatible & Anthropic-compatible). Promoting it to the default keeps users on the newest capabilities while `M2.7` / `M2.7-highspeed` remain available for compatibility.

## Testing
- JSON templates parse cleanly after `envsubst`; expected `MiniMax-M3` appears in the rendered models list and `MiniMax-M2.5` is gone
- `gofmt` clean on `generator.go`; `go build ./internal/agentconfig/...` passes; `bash -n` clean on all touched shell scripts
- No existing tests reference `MiniMax` model IDs, so no test updates required