### PR TITLE
fix(copaw): honor model-switch --no-reasoning via enable_thinking=false

### DIFF
--- a/copaw/src/copaw_worker/bridge.py
+++ b/copaw/src/copaw_worker/bridge.py
@@ -607,6 +607,18 @@ def _write_providers_json(
                     "supports_video": "video" in modalities,
                     "supports_multimodal": bool(modalities - {"text"}),
                 })
+            # Map OpenClaw ``reasoning: false`` to CoPaw generate_kwargs so
+            # OpenAI-compatible backends (e.g. DashScope Qwen hybrid models)
+            # receive extra_body.enable_thinking=false. Health preflight
+            # already disables thinking; chat must do the same when
+            # Controller/Manager marks the model non-reasoning.
+            # Model-level only: never set provider generate_kwargs here.
+            # Provider-level flags are shared across every model on the
+            # gateway and would incorrectly disable thinking for siblings.
+            if model_cfg.get("reasoning") is False:
+                model["generate_kwargs"] = {
+                    "extra_body": {"enable_thinking": False},
+                }
             models.append(model)
 
         custom_providers[provider_id] = {

--- a/copaw/tests/test_bridge.py
+++ b/copaw/tests/test_bridge.py
@@ -754,3 +754,86 @@ def test_providers_json_no_input_field_no_capability_flags():
     providers = _run_bridge_and_read_providers(cfg)
     model = providers["custom_providers"]["gw"]["models"][0]
     assert model == {"id": "plain-model", "name": "plain-model"}
+
+
+def test_providers_json_propagates_reasoning_false_as_generate_kwargs():
+    """OpenClaw ``reasoning: false`` must become CoPaw enable_thinking=false."""
+    cfg = {
+        "channels": {"matrix": {"enabled": True}},
+        "models": {
+            "providers": {
+                "gw": {
+                    "baseUrl": "http://aigw:8080/v1",
+                    "apiKey": "key123",
+                    "models": [
+                        {
+                            "id": "qwen3.6-plus",
+                            "name": "qwen3.6-plus",
+                            "reasoning": False,
+                            "input": ["text", "image"],
+                        },
+                        {
+                            "id": "claude-sonnet-4-6",
+                            "name": "claude-sonnet-4-6",
+                            "reasoning": True,
+                            "input": ["text", "image"],
+                        },
+                    ],
+                }
+            }
+        },
+        "agents": {
+            "defaults": {"model": {"primary": "gw/qwen3.6-plus"}}
+        },
+    }
+    providers = _run_bridge_and_read_providers(cfg)
+    provider = providers["custom_providers"]["gw"]
+    by_id = {m["id"]: m for m in provider["models"]}
+
+    assert by_id["qwen3.6-plus"]["generate_kwargs"] == {
+        "extra_body": {"enable_thinking": False},
+    }
+    assert "generate_kwargs" not in by_id["claude-sonnet-4-6"]
+    # Bridge keeps thinking control on the model entry only.
+    assert "generate_kwargs" not in provider
+
+
+def test_providers_json_sibling_reasoning_false_does_not_force_provider():
+    """A sibling with reasoning:false must not set provider-level generate_kwargs."""
+    cfg = {
+        "channels": {"matrix": {"enabled": True}},
+        "models": {
+            "providers": {
+                "gw": {
+                    "baseUrl": "http://aigw:8080/v1",
+                    "apiKey": "key123",
+                    "models": [
+                        {
+                            "id": "qwen3.6-plus",
+                            "name": "qwen3.6-plus",
+                            "reasoning": False,
+                            "input": ["text", "image"],
+                        },
+                        {
+                            "id": "deepseek-reasoner",
+                            "name": "deepseek-reasoner",
+                            "reasoning": True,
+                            "input": ["text"],
+                        },
+                    ],
+                }
+            }
+        },
+        "agents": {
+            "defaults": {"model": {"primary": "gw/deepseek-reasoner"}}
+        },
+    }
+    providers = _run_bridge_and_read_providers(cfg)
+    provider = providers["custom_providers"]["gw"]
+    by_id = {m["id"]: m for m in provider["models"]}
+
+    assert by_id["qwen3.6-plus"]["generate_kwargs"] == {
+        "extra_body": {"enable_thinking": False},
+    }
+    assert "generate_kwargs" not in by_id["deepseek-reasoner"]
+    assert "generate_kwargs" not in provider

--- a/manager/agent/skills/model-switch/SKILL.md
+++ b/manager/agent/skills/model-switch/SKILL.md
@@ -5,7 +5,7 @@ description: Switch the Manager Agent's own LLM model. Use when the human admin 
 
 # Model Switch
 
-Switch the Manager's own LLM model. The script tests connectivity first, then patches `openclaw.json`.
+Switch the Manager's own LLM model. The script tests connectivity first, then patches the runtime config (`openclaw.json` for OpenClaw, CoPaw provider store for CoPaw).
 
 ## Usage
 
@@ -24,21 +24,28 @@ bash /opt/agentteams/agent/skills/model-switch/scripts/update-manager-model.sh d
 
 1. Strips any `agentteams-gateway/` prefix from the model name
 2. Tests the model via `POST /v1/chat/completions` on the AI Gateway — exits with error if unreachable
-3. If the model is already in the `models` array: switches `agents.defaults.model.primary`
-4. If the model is new: adds it to the `models` array and switches primary
+3. **OpenClaw**: updates `openclaw.json` model list / primary and `reasoning`
+4. **CoPaw**: updates modern provider `~/.copaw.secret/providers/custom/agentteams-gateway.json` (model-level `generate_kwargs`) + `active_model.json`, and syncs `openclaw.json` `reasoning` / primary (bridge SoT)
 5. Always outputs `RESTART_REQUIRED`
 
 ## After running the script
 
-The script always outputs `RESTART_REQUIRED`. Run `openclaw gateway restart` to apply the change, then tell the human admin the switch is complete.
+The script always outputs `RESTART_REQUIRED`.
+- OpenClaw: run `openclaw gateway restart`
+- CoPaw: restart the CoPaw / Manager service
+
+Then tell the human admin the switch is complete.
 
 ## Reasoning control
 
 By default, reasoning (extended thinking) is enabled. To disable it, pass `--no-reasoning`.
 
+- **OpenClaw**: sets `reasoning: false` on the model entry in `openclaw.json`
+- **CoPaw**: sets model-level `generate_kwargs.extra_body.enable_thinking=false` (DashScope Qwen hybrid models), and mirrors `reasoning` onto `openclaw.json`
+
 ## On failure
 
-If the gateway test fails (non-200), the script outputs `ERROR: MODEL_NOT_REACHABLE` and exits. No changes are made to `openclaw.json`.
+If the gateway test fails (non-200), the script outputs `ERROR: MODEL_NOT_REACHABLE` and exits. No changes are made to runtime config.
 
 When you see this error, tell the human admin clearly:
 
@@ -52,7 +59,7 @@ After the admin confirms the provider and route are configured, you can retry th
 
 ## Important
 
-This skill switches the **primary model** (persisted in `openclaw.json`). After running the script, you must run `openclaw gateway restart` for the change to take effect. The human admin can also use the `/model` slash command to switch the current session's model instantly without restart, but that is non-persistent and only supports pre-configured models.
+This skill switches the **primary model** (persisted in OpenClaw `openclaw.json` or the CoPaw provider store). After running the script, restart the Manager runtime for the change to take effect. The human admin can also use the `/model` slash command to switch the current session's model instantly without restart, but that is non-persistent and only supports pre-configured models.
 
 ## Switching to an unknown model
 
@@ -77,6 +84,6 @@ When the human admin requests switching to a model you don't recognize, you MUST
 | claude-opus-4-6 | 1,000,000 | 128,000 |
 | claude-sonnet-4-6 | 1,000,000 | 64,000 |
 | claude-haiku-4-5 | 200,000 | 64,000 |
-| qwen3.5-plus | 200,000 | 64,000 |
+| qwen3.6-plus / qwen3.5-plus | 200,000 | 64,000 |
 | deepseek-chat / deepseek-reasoner / kimi-k2.5 | 256,000 | 128,000 |
 | glm-5 / MiniMax-M2.7 / MiniMax-M2.7-highspeed / MiniMax-M2.5 | 200,000 | 128,000 |

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -2,11 +2,17 @@
 # update-manager-model.sh - Hot-update the Manager Agent's model
 #
 # Patches config files in-place based on runtime:
-#   - OpenClaw: ~/manager-workspace/openclaw.json (model list + context window in one file)
-#   - CoPaw: ~/.copaw.secret/providers.json (model list) + ~/.copaw/config.json (context window)
+#   - OpenClaw: openclaw.json (model list + primary + reasoning)
+#   - CoPaw:
+#       ~/.copaw.secret/providers/custom/agentteams-gateway.json (extra_models)
+#       ~/.copaw.secret/providers/active_model.json
+#       ~/.copaw/config.json (context window)
+#       openclaw.json (bridge SoT: reasoning + primary)
 #
-# OpenClaw detects the file change (~300ms) and reloads config automatically.
-# CoPaw may require a restart.
+# --no-reasoning:
+#   OpenClaw → model.reasoning = false
+#   CoPaw    → model generate_kwargs.extra_body.enable_thinking = false
+#              + openclaw.json reasoning = false
 #
 # Usage:
 #   update-manager-model.sh <MODEL_ID> [--context-window <SIZE>] [--no-reasoning]
@@ -15,6 +21,9 @@
 #   update-manager-model.sh claude-sonnet-4-6
 #   update-manager-model.sh my-custom-model --context-window 300000
 #   update-manager-model.sh deepseek-chat --no-reasoning
+#
+# OpenClaw detects the file change (~300ms) and reloads config automatically.
+# CoPaw may require a restart.
 
 set -e
 source /opt/agentteams/scripts/lib/agentteams-env.sh
@@ -29,6 +38,68 @@ _get_max_tokens_param() {
     else
         echo "max_tokens"
     fi
+}
+
+# Patch openclaw.json primary + reasoning (OpenClaw runtime + CoPaw bridge SoT).
+# jq expressions match the historical OpenClaw path; only factored for reuse.
+_patch_openclaw_model() {
+    local openclaw_json="$1"
+    local model_exists
+    model_exists=$(jq --arg model "${MODEL_NAME}" \
+        '[.models.providers["agentteams-gateway"].models[] | select(.id == $model)] | length' \
+        "${openclaw_json}" 2>/dev/null || echo "0")
+
+    if [ "${model_exists}" -gt 0 ]; then
+        jq --arg model "${MODEL_NAME}" \
+           --argjson reasoning "${REASONING}" \
+           '(.models.providers["agentteams-gateway"].models[] | select(.id == $model)).reasoning = $reasoning
+            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
+            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
+           "${openclaw_json}" > "${TMP}" && mv "${TMP}" "${openclaw_json}"
+    else
+        jq --arg model "${MODEL_NAME}" \
+           --argjson ctx "${CTX}" \
+           --argjson max "${MAX}" \
+           --argjson reasoning "${REASONING}" \
+           --argjson input "${INPUT}" \
+           '.models.providers["agentteams-gateway"].models += [{
+               "id": $model,
+               "name": $model,
+               "reasoning": $reasoning,
+               "contextWindow": $ctx,
+               "maxTokens": $max,
+               "input": $input
+             }]
+            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
+            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
+           "${openclaw_json}" > "${TMP}" && mv "${TMP}" "${openclaw_json}"
+    fi
+    echo "${model_exists}"
+}
+
+# Ensure model in modern CoPaw extra_models; set/clear model-level enable_thinking.
+_patch_copaw_model_thinking() {
+    jq --arg model "${MODEL_NAME}" --argjson reasoning "${REASONING}" '
+        .extra_models = (.extra_models // [])
+        | if any(.extra_models[]; .id == $model) then .
+          else .extra_models += [{id: $model, name: $model}]
+          end
+        | .extra_models |= map(
+            if .id != $model then .
+            elif $reasoning == false then
+              .generate_kwargs = (.generate_kwargs // {})
+              | .generate_kwargs.extra_body =
+                  ((.generate_kwargs.extra_body // {}) + {enable_thinking: false})
+            elif .generate_kwargs.extra_body.enable_thinking? == false then
+              del(.generate_kwargs.extra_body.enable_thinking)
+              | if (.generate_kwargs.extra_body // {}) == {} then
+                  del(.generate_kwargs.extra_body) else . end
+              | if (.generate_kwargs // {}) == {} then
+                  del(.generate_kwargs) else . end
+            else .
+            end
+          )
+    ' "${COPAW_CUSTOM_PROVIDER}" > "${TMP}" && mv "${TMP}" "${COPAW_CUSTOM_PROVIDER}"
 }
 
 MODEL_NAME="${1:-}"
@@ -65,11 +136,18 @@ done
 # Determine config files based on runtime
 if [ "${MANAGER_RUNTIME}" = "copaw" ]; then
     CONFIG_FILE="${HOME}/.copaw/config.json"
-    PROVIDERS_FILE="${HOME}/.copaw.secret/providers.json"
-    if [ ! -f "${CONFIG_FILE}" ] || [ ! -f "${PROVIDERS_FILE}" ]; then
-        echo "ERROR: CoPaw config not found"
-        echo "  config.json: ${CONFIG_FILE} ($([ -f "${CONFIG_FILE}" ] && echo 'exists' || echo 'MISSING'))"
-        echo "  providers.json: ${PROVIDERS_FILE} ($([ -f "${PROVIDERS_FILE}" ] && echo 'exists' || echo 'MISSING'))"
+    COPAW_CUSTOM_PROVIDER="${HOME}/.copaw.secret/providers/custom/agentteams-gateway.json"
+    COPAW_ACTIVE_MODEL="${HOME}/.copaw.secret/providers/active_model.json"
+    OPENCLAW_JSON="${HOME}/openclaw.json"
+    [ -f "${OPENCLAW_JSON}" ] || OPENCLAW_JSON="${HOME}/manager-workspace/openclaw.json"
+
+    if [ ! -f "${CONFIG_FILE}" ]; then
+        echo "ERROR: CoPaw config not found: ${CONFIG_FILE}"
+        exit 1
+    fi
+    if [ ! -f "${COPAW_CUSTOM_PROVIDER}" ]; then
+        echo "ERROR: CoPaw provider not found: ${COPAW_CUSTOM_PROVIDER}"
+        echo "This skill expects the modern CoPaw provider layout."
         exit 1
     fi
 else
@@ -81,6 +159,7 @@ else
         echo "ERROR: OpenClaw config not found (checked ~/manager-workspace/openclaw.json and ~/openclaw.json)"
         exit 1
     fi
+    OPENCLAW_JSON="${CONFIG_FILE}"
 fi
 
 # Resolve context window and max tokens
@@ -170,53 +249,36 @@ rm -f /tmp/model-test-resp.json
 TMP=$(mktemp)
 
 if [ "${MANAGER_RUNTIME}" = "copaw" ]; then
-    # ── CoPaw: update providers.json (model list) + config.json (context window) ──
-    # providers.json: .custom_providers["agentteams-gateway"].models + .active_llm.model
-    # config.json: .agents.running.max_input_length
-    jq --arg model "${MODEL_NAME}" \
-       '.custom_providers["agentteams-gateway"].models = [{"id": $model, "name": $model}]
-        | .active_llm.model = $model' \
-       "${PROVIDERS_FILE}" > "${TMP}" && mv "${TMP}" "${PROVIDERS_FILE}"
-    cp "${PROVIDERS_FILE}" "${HOME}/.copaw/providers.json"
+    # Model-level enable_thinking only (no shared provider-level flag).
+    _patch_copaw_model_thinking
+    chmod 600 "${COPAW_CUSTOM_PROVIDER}" 2>/dev/null || true
+
+    mkdir -p "$(dirname "${COPAW_ACTIVE_MODEL}")"
+    jq -n --arg model "${MODEL_NAME}" \
+        '{provider_id: "agentteams-gateway", model: $model}' \
+        > "${TMP}" && mv "${TMP}" "${COPAW_ACTIVE_MODEL}"
+    chmod 600 "${COPAW_ACTIVE_MODEL}" 2>/dev/null || true
 
     jq --argjson ctx "${CTX}" \
        '.agents.running.max_input_length = $ctx' \
        "${CONFIG_FILE}" > "${TMP}" && mv "${TMP}" "${CONFIG_FILE}"
 
-    log "Done. CoPaw model is now: ${MODEL_NAME} (ctx=${CTX})"
+    if [ -f "${OPENCLAW_JSON}" ]; then
+        _patch_openclaw_model "${OPENCLAW_JSON}" >/dev/null
+        log "Synced openclaw.json reasoning=${REASONING} for ${MODEL_NAME}"
+    else
+        log "WARN: openclaw.json not found; provider store updated but bridge SoT was not synced"
+    fi
+
+    log "Done. CoPaw model is now: ${MODEL_NAME} (ctx=${CTX}, reasoning=${REASONING})"
     echo ""
     echo "RESTART_REQUIRED: Restart the CoPaw service to apply the model switch."
 else
     # ── OpenClaw: update openclaw.json ──
-    MODEL_EXISTS=$(jq --arg model "${MODEL_NAME}" \
-        '[.models.providers["agentteams-gateway"].models[] | select(.id == $model)] | length' \
-        "${CONFIG_FILE}" 2>/dev/null || echo "0")
-
+    MODEL_EXISTS=$(_patch_openclaw_model "${OPENCLAW_JSON}")
     if [ "${MODEL_EXISTS}" -gt 0 ]; then
-        jq --arg model "${MODEL_NAME}" \
-           --argjson reasoning "${REASONING}" \
-           '(.models.providers["agentteams-gateway"].models[] | select(.id == $model)).reasoning = $reasoning
-            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
-            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
-           "${CONFIG_FILE}" > "${TMP}" && mv "${TMP}" "${CONFIG_FILE}"
         log "Done. Model is now: ${MODEL_NAME}"
     else
-        jq --arg model "${MODEL_NAME}" \
-           --argjson ctx "${CTX}" \
-           --argjson max "${MAX}" \
-           --argjson reasoning "${REASONING}" \
-           --argjson input "${INPUT}" \
-           '.models.providers["agentteams-gateway"].models += [{
-               "id": $model,
-               "name": $model,
-               "reasoning": $reasoning,
-               "contextWindow": $ctx,
-               "maxTokens": $max,
-               "input": $input
-             }]
-            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
-            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
-           "${CONFIG_FILE}" > "${TMP}" && mv "${TMP}" "${CONFIG_FILE}"
         log "Done. Model '${MODEL_NAME}' has been added to the models list."
     fi
     echo ""


### PR DESCRIPTION
Fixes #1126

## Summary

- CoPaw Manager `model-switch` ignored `--no-reasoning` (only logged `reasoning=false`) while OpenClaw already persisted `reasoning: false`.
- Persist **model-level** `generate_kwargs.extra_body.enable_thinking=false` on the modern CoPaw provider store (`providers/custom/agentteams-gateway.json` + `active_model.json`).
- Sync `openclaw.json` `reasoning` / primary as bridge SoT so CoPaw restart / re-bridge does not wipe the setting from an empty local write.
- Bridge maps `openclaw.json` `reasoning: false` → model-level CoPaw `generate_kwargs` only (no shared provider-level flag).

## Test plan

- [x] jq / script path: `--no-reasoning` writes model-level `enable_thinking=false`; omit flag clears it
- [x] Local Docker CoPaw Manager (`docker cp` this script): `update-manager-model.sh <model> --no-reasoning` → provider has `enable_thinking=false`, `openclaw.json` has `reasoning=false` (checked immediately after write)
- [x] Clear path (no `--no-reasoning`) restores both sides
- [x] Bridge unit tests added for `reasoning: false` → model-level `generate_kwargs` (and sibling does not force provider-level)
- [x] Restart CoPaw / Manager and confirm chat TTFT drops (no long thinking)

## Notes

- Modern CoPaw provider layout only.
- MinIO Remote→Local overwriting a local `openclaw.json` write is a **separate** persistence issue and is **not** fixed in this PR.