### PR TITLE
fix(controller): preserve model-switch openclaw reasoning across Manager reconcile

### DIFF
--- a/agentteams-controller/internal/service/manager_config.go
+++ b/agentteams-controller/internal/service/manager_config.go
@@ -90,6 +90,18 @@ func (l *ManagerConfigStore) writeManagerLocalConfig(data []byte) {
 // PutManagerConfig writes the Manager's openclaw.json to OSS, merging the
 // new config with any existing groupAllowFrom entries to avoid overwriting
 // additions made by UpdateManagerGroupAllowFrom (e.g. team leader IDs).
+//
+// Existing config is loaded from the shared local mount first (live Manager
+// workspace), then OSS. Hot-updates such as model-switch `--no-reasoning`
+// therefore win over the next Manager reconcile regenerate — but only when
+// AgentFSDir is set (embedded / shared-mount). In k8s without that mount
+// the load falls through to OSS; if Manager could not write
+// agents/manager/openclaw.json (often 403), OSS may still hold stale
+// reasoning and the overwrite from issue #1128 can persist.
+//
+// To apply a new AGENTTEAMS_MODEL_REASONING / CR default, update the live
+// openclaw.json (e.g. re-run model-switch) so the workspace matches the
+// desired flag.
 func (l *ManagerConfigStore) PutManagerConfig(configJSON []byte) error {
 	if !l.Enabled() {
 		return nil
@@ -102,14 +114,17 @@ func (l *ManagerConfigStore) PutManagerConfig(configJSON []byte) error {
 	key := l.managerAgentPrefix() + "/openclaw.json"
 
 	// Read existing config to preserve user customizations on top of the
-	// generated defaults: groupAllowFrom additions plus user-modified plugin
-	// entries (e.g. memory-core dreaming schedule, extra load paths).
-	existingData, err := l.OSS.GetObject(ctx, key)
-	if err == nil && len(existingData) > 0 {
+	// generated defaults: groupAllowFrom additions, per-model reasoning
+	// (model-switch), plus user-modified plugin entries.
+	// Load errors are already logged. Continue with generated config when
+	// existing data is missing so reconcile still writes a usable file.
+	existingData, _ := l.loadExistingManagerConfig(ctx, key)
+	if len(existingData) > 0 {
 		var existingCfg map[string]interface{}
 		var newCfg map[string]interface{}
 		if json.Unmarshal(existingData, &existingCfg) == nil && json.Unmarshal(configJSON, &newCfg) == nil {
 			mergeGroupAllowFrom(existingCfg, newCfg)
+			mergeModelReasoning(existingCfg, newCfg)
 			if merged, mErr := json.MarshalIndent(newCfg, "", "  "); mErr == nil {
 				configJSON = merged
 			}
@@ -126,6 +141,128 @@ func (l *ManagerConfigStore) PutManagerConfig(configJSON []byte) error {
 	}
 	l.writeManagerLocalConfig(configJSON)
 	return nil
+}
+
+// loadExistingManagerConfig prefers the shared local Manager workspace (embedded
+// bind-mount), then falls back to OSS. Local-first matters because model-switch
+// updates the workspace immediately while Manager may lack ACL to push
+// agents/manager/ in MinIO.
+//
+// Local bytes are used only when they unmarshal as a JSON object. A
+// corrupt/partial live file falls through to OSS. OSS not-found is not an
+// error; any other OSS read failure is logged and returned so callers such as
+// UpdateManagerGroupAllowFrom can surface it instead of silently dropping
+// the mutation.
+func (l *ManagerConfigStore) loadExistingManagerConfig(ctx context.Context, key string) ([]byte, error) {
+	logger := log.FromContext(ctx).WithName("manager-config")
+
+	if path := l.managerLocalConfigPath(); path != "" {
+		data, err := os.ReadFile(path)
+		switch {
+		case err == nil && len(data) > 0:
+			var probe map[string]interface{}
+			if json.Unmarshal(data, &probe) == nil {
+				return data, nil
+			}
+			logger.Info("local manager openclaw.json is not valid JSON; falling back to OSS", "path", path)
+		case err == nil:
+			// empty file — treat as missing
+		case os.IsNotExist(err):
+			// first write or no live workspace yet
+		default:
+			logger.Error(err, "failed to read local manager openclaw.json; falling back to OSS", "path", path)
+		}
+	}
+
+	data, err := l.OSS.GetObject(ctx, key)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		logger.Error(err, "failed to read manager openclaw.json from OSS", "key", key)
+		return nil, fmt.Errorf("read manager config from OSS: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	return data, nil
+}
+
+// mergeModelReasoning copies per-model reasoning flags from old into new so a
+// Controller regenerate does not undo model-switch --no-reasoning (or similar
+// hot-updates) that already landed on the live openclaw.json.
+//
+// Policy: existing/live reasoning always wins over generated defaults when the
+// model id is present in both. Intentional CR/env flips must update the live
+// workspace (or OSS if local is absent), not rely on regenerate alone.
+func mergeModelReasoning(oldCfg, newCfg map[string]interface{}) {
+	oldByID := modelEntriesByID(oldCfg)
+	newEntries := modelEntries(newCfg)
+	if len(oldByID) == 0 || len(newEntries) == 0 {
+		return
+	}
+	for _, m := range newEntries {
+		id, _ := m["id"].(string)
+		if id == "" {
+			continue
+		}
+		old, ok := oldByID[id]
+		if !ok {
+			continue
+		}
+		if reasoning, has := old["reasoning"]; has {
+			m["reasoning"] = reasoning
+		}
+	}
+}
+
+func modelEntries(cfg map[string]interface{}) []map[string]interface{} {
+	models, _ := cfg["models"].(map[string]interface{})
+	if models == nil {
+		return nil
+	}
+	providers, _ := models["providers"].(map[string]interface{})
+	if providers == nil {
+		return nil
+	}
+	// Prefer the AgentTeams gateway provider; otherwise scan all providers.
+	order := make([]string, 0, len(providers)+1)
+	if _, ok := providers["agentteams-gateway"]; ok {
+		order = append(order, "agentteams-gateway")
+	}
+	for name := range providers {
+		if name != "agentteams-gateway" {
+			order = append(order, name)
+		}
+	}
+	out := make([]map[string]interface{}, 0)
+	for _, name := range order {
+		provider, _ := providers[name].(map[string]interface{})
+		if provider == nil {
+			continue
+		}
+		raw, _ := provider["models"].([]interface{})
+		for _, item := range raw {
+			if m, ok := item.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
+func modelEntriesByID(cfg map[string]interface{}) map[string]map[string]interface{} {
+	entries := modelEntries(cfg)
+	if len(entries) == 0 {
+		return nil
+	}
+	byID := make(map[string]map[string]interface{}, len(entries))
+	for _, m := range entries {
+		if id, ok := m["id"].(string); ok && id != "" {
+			byID[id] = m
+		}
+	}
+	return byID
 }
 
 // mergeGroupAllowFrom copies any extra groupAllowFrom entries from old config
@@ -174,12 +311,14 @@ func (l *ManagerConfigStore) UpdateManagerGroupAllowFrom(workerMatrixID string, 
 	ctx := context.Background()
 	key := l.managerAgentPrefix() + "/openclaw.json"
 
-	data, err := l.OSS.GetObject(ctx, key)
+	// Same local-first load as PutManagerConfig: groupAllowFrom edits must not
+	// revive a stale OSS copy of model reasoning over the live workspace.
+	data, err := l.loadExistingManagerConfig(ctx, key)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read manager config from OSS: %w", err)
+		return err
+	}
+	if len(data) == 0 {
+		return nil
 	}
 
 	var config map[string]interface{}

--- a/agentteams-controller/internal/service/manager_config.go
+++ b/agentteams-controller/internal/service/manager_config.go
@@ -90,6 +90,12 @@ func (l *ManagerConfigStore) writeManagerLocalConfig(data []byte) {
 // PutManagerConfig writes the Manager's openclaw.json to OSS, merging the
 // new config with any existing groupAllowFrom entries to avoid overwriting
 // additions made by UpdateManagerGroupAllowFrom (e.g. team leader IDs).
+//
+// Existing config is loaded from the shared local mount first (live Manager
+// workspace), then OSS. Hot-updates such as model-switch `--no-reasoning`
+// therefore win over the next Manager reconcile regenerate. To apply a new
+// AGENTTEAMS_MODEL_REASONING / CR default, update the live openclaw.json
+// (e.g. re-run model-switch) so the workspace matches the desired flag.
 func (l *ManagerConfigStore) PutManagerConfig(configJSON []byte) error {
 	if !l.Enabled() {
 		return nil
@@ -102,14 +108,15 @@ func (l *ManagerConfigStore) PutManagerConfig(configJSON []byte) error {
 	key := l.managerAgentPrefix() + "/openclaw.json"
 
 	// Read existing config to preserve user customizations on top of the
-	// generated defaults: groupAllowFrom additions plus user-modified plugin
-	// entries (e.g. memory-core dreaming schedule, extra load paths).
-	existingData, err := l.OSS.GetObject(ctx, key)
-	if err == nil && len(existingData) > 0 {
+	// generated defaults: groupAllowFrom additions, per-model reasoning
+	// (model-switch), plus user-modified plugin entries.
+	existingData := l.loadExistingManagerConfig(ctx, key)
+	if len(existingData) > 0 {
 		var existingCfg map[string]interface{}
 		var newCfg map[string]interface{}
 		if json.Unmarshal(existingData, &existingCfg) == nil && json.Unmarshal(configJSON, &newCfg) == nil {
 			mergeGroupAllowFrom(existingCfg, newCfg)
+			mergeModelReasoning(existingCfg, newCfg)
 			if merged, mErr := json.MarshalIndent(newCfg, "", "  "); mErr == nil {
 				configJSON = merged
 			}
@@ -126,6 +133,100 @@ func (l *ManagerConfigStore) PutManagerConfig(configJSON []byte) error {
 	}
 	l.writeManagerLocalConfig(configJSON)
 	return nil
+}
+
+// loadExistingManagerConfig prefers the shared local Manager workspace (embedded
+// bind-mount), then falls back to OSS. Local-first matters because model-switch
+// updates the workspace immediately while Manager may lack ACL to push
+// agents/manager/ in MinIO.
+func (l *ManagerConfigStore) loadExistingManagerConfig(ctx context.Context, key string) []byte {
+	if path := l.managerLocalConfigPath(); path != "" {
+		if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+			return data
+		}
+	}
+	data, err := l.OSS.GetObject(ctx, key)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	return data
+}
+
+// mergeModelReasoning copies per-model reasoning flags from old into new so a
+// Controller regenerate does not undo model-switch --no-reasoning (or similar
+// hot-updates) that already landed on the live openclaw.json.
+//
+// Policy: existing/live reasoning always wins over generated defaults when the
+// model id is present in both. Intentional CR/env flips must update the live
+// workspace (or OSS if local is absent), not rely on regenerate alone.
+func mergeModelReasoning(oldCfg, newCfg map[string]interface{}) {
+	oldByID := modelEntriesByID(oldCfg)
+	newEntries := modelEntries(newCfg)
+	if len(oldByID) == 0 || len(newEntries) == 0 {
+		return
+	}
+	for _, m := range newEntries {
+		id, _ := m["id"].(string)
+		if id == "" {
+			continue
+		}
+		old, ok := oldByID[id]
+		if !ok {
+			continue
+		}
+		if reasoning, has := old["reasoning"]; has {
+			m["reasoning"] = reasoning
+		}
+	}
+}
+
+func modelEntries(cfg map[string]interface{}) []map[string]interface{} {
+	models, _ := cfg["models"].(map[string]interface{})
+	if models == nil {
+		return nil
+	}
+	providers, _ := models["providers"].(map[string]interface{})
+	if providers == nil {
+		return nil
+	}
+	// Prefer the AgentTeams gateway provider; otherwise scan all providers.
+	order := make([]string, 0, len(providers)+1)
+	if _, ok := providers["agentteams-gateway"]; ok {
+		order = append(order, "agentteams-gateway")
+	}
+	for name := range providers {
+		if name != "agentteams-gateway" {
+			order = append(order, name)
+		}
+	}
+	out := make([]map[string]interface{}, 0)
+	for _, name := range order {
+		provider, _ := providers[name].(map[string]interface{})
+		if provider == nil {
+			continue
+		}
+		raw, _ := provider["models"].([]interface{})
+		for _, item := range raw {
+			if m, ok := item.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
+func modelEntriesByID(cfg map[string]interface{}) map[string]map[string]interface{} {
+	entries := modelEntries(cfg)
+	if len(entries) == 0 {
+		return nil
+	}
+	byID := make(map[string]map[string]interface{}, len(entries))
+	for _, m := range entries {
+		if id, ok := m["id"].(string); ok && id != "" {
+			byID[id] = m
+		}
+	}
+	return byID
 }
 
 // mergeGroupAllowFrom copies any extra groupAllowFrom entries from old config
@@ -174,12 +275,11 @@ func (l *ManagerConfigStore) UpdateManagerGroupAllowFrom(workerMatrixID string, 
 	ctx := context.Background()
 	key := l.managerAgentPrefix() + "/openclaw.json"
 
-	data, err := l.OSS.GetObject(ctx, key)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read manager config from OSS: %w", err)
+	// Same local-first load as PutManagerConfig: groupAllowFrom edits must not
+	// revive a stale OSS copy of model reasoning over the live workspace.
+	data := l.loadExistingManagerConfig(ctx, key)
+	if len(data) == 0 {
+		return nil
 	}
 
 	var config map[string]interface{}

--- a/agentteams-controller/internal/service/manager_config_test.go
+++ b/agentteams-controller/internal/service/manager_config_test.go
@@ -3,10 +3,303 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss/ossfake"
 )
+
+// getObjectStub wraps Memory so tests can inject a non-NotExist GetObject error.
+type getObjectStub struct {
+	*ossfake.Memory
+	getErr error
+}
+
+func (s *getObjectStub) GetObject(ctx context.Context, key string) ([]byte, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.Memory.GetObject(ctx, key)
+}
+
+func TestPutManagerConfig_PreservesModelReasoning(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+
+	existing := []byte(`{
+		"models": {
+			"providers": {
+				"agentteams-gateway": {
+					"models": [
+						{"id": "qwen3.6-plus", "name": "qwen3.6-plus", "reasoning": false},
+						{"id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true}
+					]
+				}
+			}
+		}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", existing); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+	})
+
+	// Controller regenerate defaults reasoning=true for the active model.
+	generated := []byte(`{
+		"models": {
+			"providers": {
+				"agentteams-gateway": {
+					"models": [
+						{"id": "qwen3.6-plus", "name": "qwen3.6-plus", "reasoning": true},
+						{"id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true}
+					]
+				}
+			}
+		}
+	}`)
+
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	byID := modelEntriesByID(got)
+	if byID["qwen3.6-plus"]["reasoning"] != false {
+		t.Errorf("qwen3.6-plus reasoning not preserved: got %v", byID["qwen3.6-plus"]["reasoning"])
+	}
+	if byID["claude-sonnet-4-6"]["reasoning"] != true {
+		t.Errorf("claude-sonnet-4-6 reasoning changed unexpectedly: got %v", byID["claude-sonnet-4-6"]["reasoning"])
+	}
+}
+
+func TestPutManagerConfig_PrefersLocalReasoningOverStaleOSS(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	dir := t.TempDir()
+	managerDir := dir + "/manager"
+	if err := os.MkdirAll(managerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale OSS still has reasoning=true.
+	staleOSS := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", staleOSS); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+	// Live workspace (model-switch) already wrote reasoning=false.
+	local := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": false}
+		]}}}
+	}`)
+	if err := os.WriteFile(managerDir+"/openclaw.json", local, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+		AgentFSDir:   dir,
+	})
+
+	generated := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if modelEntriesByID(got)["qwen3.6-plus"]["reasoning"] != false {
+		t.Fatalf("expected local reasoning=false to win over stale OSS, got %v", modelEntriesByID(got)["qwen3.6-plus"]["reasoning"])
+	}
+}
+
+func TestUpdateManagerGroupAllowFrom_PrefersLocalConfig(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	dir := t.TempDir()
+	managerDir := dir + "/manager"
+	if err := os.MkdirAll(managerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleOSS := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": []}},
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", staleOSS); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+	local := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": []}},
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": false}
+		]}}}
+	}`)
+	if err := os.WriteFile(managerDir+"/openclaw.json", local, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+		AgentFSDir:   dir,
+	})
+	if err := lc.UpdateManagerGroupAllowFrom("@worker1:agentteams.local", true); err != nil {
+		t.Fatalf("UpdateManagerGroupAllowFrom: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if modelEntriesByID(got)["qwen3.6-plus"]["reasoning"] != false {
+		t.Fatalf("groupAllowFrom update revived stale OSS reasoning: got %v", modelEntriesByID(got)["qwen3.6-plus"]["reasoning"])
+	}
+	allow := got["channels"].(map[string]interface{})["matrix"].(map[string]interface{})["groupAllowFrom"].([]interface{})
+	if len(allow) != 1 || allow[0] != "@worker1:agentteams.local" {
+		t.Fatalf("groupAllowFrom not updated: %v", allow)
+	}
+}
+
+func TestPutManagerConfig_MalformedLocalFallsBackToOSS(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	dir := t.TempDir()
+	managerDir := dir + "/manager"
+	if err := os.MkdirAll(managerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ossCfg := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": false}
+		]}}}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", ossCfg); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+	if err := os.WriteFile(managerDir+"/openclaw.json", []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+		AgentFSDir:   dir,
+	})
+	generated := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if modelEntriesByID(got)["qwen3.6-plus"]["reasoning"] != false {
+		t.Fatalf("expected valid OSS reasoning=false after corrupt local, got %v", modelEntriesByID(got)["qwen3.6-plus"]["reasoning"])
+	}
+}
+
+func TestUpdateManagerGroupAllowFrom_OSSOnly(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	existing := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": []}},
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": false}
+		]}}}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", existing); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+		// AgentFSDir empty: k8s / OSS-only path.
+	})
+	if err := lc.UpdateManagerGroupAllowFrom("@worker1:agentteams.local", true); err != nil {
+		t.Fatalf("UpdateManagerGroupAllowFrom: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if modelEntriesByID(got)["qwen3.6-plus"]["reasoning"] != false {
+		t.Fatalf("OSS-only update lost reasoning: got %v", modelEntriesByID(got)["qwen3.6-plus"]["reasoning"])
+	}
+	allow := got["channels"].(map[string]interface{})["matrix"].(map[string]interface{})["groupAllowFrom"].([]interface{})
+	if len(allow) != 1 || allow[0] != "@worker1:agentteams.local" {
+		t.Fatalf("groupAllowFrom not updated on OSS-only path: %v", allow)
+	}
+}
+
+func TestUpdateManagerGroupAllowFrom_OSSReadError(t *testing.T) {
+	stub := &getObjectStub{Memory: ossfake.NewMemory(), getErr: errors.New("minio unavailable")}
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          stub,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+	})
+	err := lc.UpdateManagerGroupAllowFrom("@worker1:agentteams.local", true)
+	if err == nil {
+		t.Fatal("expected OSS read error to be returned, got nil")
+	}
+	if !errors.Is(err, stub.getErr) {
+		t.Fatalf("expected wrapped OSS read error, got %v", err)
+	}
+}
 
 func TestPutManagerConfig_PreservesUserPluginEntries(t *testing.T) {
 	fake := ossfake.NewMemory()

--- a/agentteams-controller/internal/service/manager_config_test.go
+++ b/agentteams-controller/internal/service/manager_config_test.go
@@ -3,10 +3,184 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss/ossfake"
 )
+
+func TestPutManagerConfig_PreservesModelReasoning(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+
+	existing := []byte(`{
+		"models": {
+			"providers": {
+				"agentteams-gateway": {
+					"models": [
+						{"id": "qwen3.6-plus", "name": "qwen3.6-plus", "reasoning": false},
+						{"id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true}
+					]
+				}
+			}
+		}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", existing); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+	})
+
+	// Controller regenerate defaults reasoning=true for the active model.
+	generated := []byte(`{
+		"models": {
+			"providers": {
+				"agentteams-gateway": {
+					"models": [
+						{"id": "qwen3.6-plus", "name": "qwen3.6-plus", "reasoning": true},
+						{"id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true}
+					]
+				}
+			}
+		}
+	}`)
+
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	byID := modelEntriesByID(got)
+	if byID["qwen3.6-plus"]["reasoning"] != false {
+		t.Errorf("qwen3.6-plus reasoning not preserved: got %v", byID["qwen3.6-plus"]["reasoning"])
+	}
+	if byID["claude-sonnet-4-6"]["reasoning"] != true {
+		t.Errorf("claude-sonnet-4-6 reasoning changed unexpectedly: got %v", byID["claude-sonnet-4-6"]["reasoning"])
+	}
+}
+
+func TestPutManagerConfig_PrefersLocalReasoningOverStaleOSS(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	dir := t.TempDir()
+	managerDir := dir + "/manager"
+	if err := os.MkdirAll(managerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale OSS still has reasoning=true.
+	staleOSS := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", staleOSS); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+	// Live workspace (model-switch) already wrote reasoning=false.
+	local := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": false}
+		]}}}
+	}`)
+	if err := os.WriteFile(managerDir+"/openclaw.json", local, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+		AgentFSDir:   dir,
+	})
+
+	generated := []byte(`{
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if modelEntriesByID(got)["qwen3.6-plus"]["reasoning"] != false {
+		t.Fatalf("expected local reasoning=false to win over stale OSS, got %v", modelEntriesByID(got)["qwen3.6-plus"]["reasoning"])
+	}
+}
+
+func TestUpdateManagerGroupAllowFrom_PrefersLocalConfig(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	dir := t.TempDir()
+	managerDir := dir + "/manager"
+	if err := os.MkdirAll(managerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleOSS := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": []}},
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": true}
+		]}}}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", staleOSS); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+	local := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": []}},
+		"models": {"providers": {"agentteams-gateway": {"models": [
+			{"id": "qwen3.6-plus", "reasoning": false}
+		]}}}
+	}`)
+	if err := os.WriteFile(managerDir+"/openclaw.json", local, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lc := NewManagerConfigStore(ManagerConfigStoreConfig{
+		OSS:          fake,
+		MatrixDomain: "agentteams.local",
+		ManagerName:  "manager",
+		AgentFSDir:   dir,
+	})
+	if err := lc.UpdateManagerGroupAllowFrom("@worker1:agentteams.local", true); err != nil {
+		t.Fatalf("UpdateManagerGroupAllowFrom: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if modelEntriesByID(got)["qwen3.6-plus"]["reasoning"] != false {
+		t.Fatalf("groupAllowFrom update revived stale OSS reasoning: got %v", modelEntriesByID(got)["qwen3.6-plus"]["reasoning"])
+	}
+	allow := got["channels"].(map[string]interface{})["matrix"].(map[string]interface{})["groupAllowFrom"].([]interface{})
+	if len(allow) != 1 || allow[0] != "@worker1:agentteams.local" {
+		t.Fatalf("groupAllowFrom not updated: %v", allow)
+	}
+}
 
 func TestPutManagerConfig_PreservesUserPluginEntries(t *testing.T) {
 	fake := ossfake.NewMemory()

--- a/copaw/src/copaw_worker/bridge.py
+++ b/copaw/src/copaw_worker/bridge.py
@@ -607,6 +607,18 @@ def _write_providers_json(
                     "supports_video": "video" in modalities,
                     "supports_multimodal": bool(modalities - {"text"}),
                 })
+            # Map OpenClaw ``reasoning: false`` to CoPaw generate_kwargs so
+            # OpenAI-compatible backends (e.g. DashScope Qwen hybrid models)
+            # receive extra_body.enable_thinking=false. Health preflight
+            # already disables thinking; chat must do the same when
+            # Controller/Manager marks the model non-reasoning.
+            # Model-level only: never set provider generate_kwargs here.
+            # Provider-level flags are shared across every model on the
+            # gateway and would incorrectly disable thinking for siblings.
+            if model_cfg.get("reasoning") is False:
+                model["generate_kwargs"] = {
+                    "extra_body": {"enable_thinking": False},
+                }
             models.append(model)
 
         custom_providers[provider_id] = {

--- a/copaw/tests/test_bridge.py
+++ b/copaw/tests/test_bridge.py
@@ -754,3 +754,86 @@ def test_providers_json_no_input_field_no_capability_flags():
     providers = _run_bridge_and_read_providers(cfg)
     model = providers["custom_providers"]["gw"]["models"][0]
     assert model == {"id": "plain-model", "name": "plain-model"}
+
+
+def test_providers_json_propagates_reasoning_false_as_generate_kwargs():
+    """OpenClaw ``reasoning: false`` must become CoPaw enable_thinking=false."""
+    cfg = {
+        "channels": {"matrix": {"enabled": True}},
+        "models": {
+            "providers": {
+                "gw": {
+                    "baseUrl": "http://aigw:8080/v1",
+                    "apiKey": "key123",
+                    "models": [
+                        {
+                            "id": "qwen3.6-plus",
+                            "name": "qwen3.6-plus",
+                            "reasoning": False,
+                            "input": ["text", "image"],
+                        },
+                        {
+                            "id": "claude-sonnet-4-6",
+                            "name": "claude-sonnet-4-6",
+                            "reasoning": True,
+                            "input": ["text", "image"],
+                        },
+                    ],
+                }
+            }
+        },
+        "agents": {
+            "defaults": {"model": {"primary": "gw/qwen3.6-plus"}}
+        },
+    }
+    providers = _run_bridge_and_read_providers(cfg)
+    provider = providers["custom_providers"]["gw"]
+    by_id = {m["id"]: m for m in provider["models"]}
+
+    assert by_id["qwen3.6-plus"]["generate_kwargs"] == {
+        "extra_body": {"enable_thinking": False},
+    }
+    assert "generate_kwargs" not in by_id["claude-sonnet-4-6"]
+    # Bridge keeps thinking control on the model entry only.
+    assert "generate_kwargs" not in provider
+
+
+def test_providers_json_sibling_reasoning_false_does_not_force_provider():
+    """A sibling with reasoning:false must not set provider-level generate_kwargs."""
+    cfg = {
+        "channels": {"matrix": {"enabled": True}},
+        "models": {
+            "providers": {
+                "gw": {
+                    "baseUrl": "http://aigw:8080/v1",
+                    "apiKey": "key123",
+                    "models": [
+                        {
+                            "id": "qwen3.6-plus",
+                            "name": "qwen3.6-plus",
+                            "reasoning": False,
+                            "input": ["text", "image"],
+                        },
+                        {
+                            "id": "deepseek-reasoner",
+                            "name": "deepseek-reasoner",
+                            "reasoning": True,
+                            "input": ["text"],
+                        },
+                    ],
+                }
+            }
+        },
+        "agents": {
+            "defaults": {"model": {"primary": "gw/deepseek-reasoner"}}
+        },
+    }
+    providers = _run_bridge_and_read_providers(cfg)
+    provider = providers["custom_providers"]["gw"]
+    by_id = {m["id"]: m for m in provider["models"]}
+
+    assert by_id["qwen3.6-plus"]["generate_kwargs"] == {
+        "extra_body": {"enable_thinking": False},
+    }
+    assert "generate_kwargs" not in by_id["deepseek-reasoner"]
+    assert "generate_kwargs" not in provider

--- a/manager/agent/skills/model-switch/SKILL.md
+++ b/manager/agent/skills/model-switch/SKILL.md
@@ -5,7 +5,7 @@ description: Switch the Manager Agent's own LLM model. Use when the human admin 
 
 # Model Switch
 
-Switch the Manager's own LLM model. The script tests connectivity first, then patches `openclaw.json`.
+Switch the Manager's own LLM model. The script tests connectivity first, then patches the runtime config (`openclaw.json` for OpenClaw, CoPaw provider store for CoPaw).
 
 ## Usage
 
@@ -24,21 +24,28 @@ bash /opt/agentteams/agent/skills/model-switch/scripts/update-manager-model.sh d
 
 1. Strips any `agentteams-gateway/` prefix from the model name
 2. Tests the model via `POST /v1/chat/completions` on the AI Gateway — exits with error if unreachable
-3. If the model is already in the `models` array: switches `agents.defaults.model.primary`
-4. If the model is new: adds it to the `models` array and switches primary
+3. **OpenClaw**: updates `openclaw.json` model list / primary and `reasoning`
+4. **CoPaw**: updates modern provider `~/.copaw.secret/providers/custom/agentteams-gateway.json` (model-level `generate_kwargs`) + `active_model.json`, and syncs `openclaw.json` `reasoning` / primary (bridge SoT)
 5. Always outputs `RESTART_REQUIRED`
 
 ## After running the script
 
-The script always outputs `RESTART_REQUIRED`. Run `openclaw gateway restart` to apply the change, then tell the human admin the switch is complete.
+The script always outputs `RESTART_REQUIRED`.
+- OpenClaw: run `openclaw gateway restart`
+- CoPaw: restart the CoPaw / Manager service
+
+Then tell the human admin the switch is complete.
 
 ## Reasoning control
 
 By default, reasoning (extended thinking) is enabled. To disable it, pass `--no-reasoning`.
 
+- **OpenClaw**: sets `reasoning: false` on the model entry in `openclaw.json`
+- **CoPaw**: sets model-level `generate_kwargs.extra_body.enable_thinking=false` (DashScope Qwen hybrid models), and mirrors `reasoning` onto `openclaw.json`
+
 ## On failure
 
-If the gateway test fails (non-200), the script outputs `ERROR: MODEL_NOT_REACHABLE` and exits. No changes are made to `openclaw.json`.
+If the gateway test fails (non-200), the script outputs `ERROR: MODEL_NOT_REACHABLE` and exits. No changes are made to runtime config.
 
 When you see this error, tell the human admin clearly:
 
@@ -52,7 +59,7 @@ After the admin confirms the provider and route are configured, you can retry th
 
 ## Important
 
-This skill switches the **primary model** (persisted in `openclaw.json`). After running the script, you must run `openclaw gateway restart` for the change to take effect. The human admin can also use the `/model` slash command to switch the current session's model instantly without restart, but that is non-persistent and only supports pre-configured models.
+This skill switches the **primary model** (persisted in OpenClaw `openclaw.json` or the CoPaw provider store). After running the script, restart the Manager runtime for the change to take effect. The human admin can also use the `/model` slash command to switch the current session's model instantly without restart, but that is non-persistent and only supports pre-configured models.
 
 ## Switching to an unknown model
 
@@ -77,6 +84,6 @@ When the human admin requests switching to a model you don't recognize, you MUST
 | claude-opus-4-6 | 1,000,000 | 128,000 |
 | claude-sonnet-4-6 | 1,000,000 | 64,000 |
 | claude-haiku-4-5 | 200,000 | 64,000 |
-| qwen3.5-plus | 200,000 | 64,000 |
+| qwen3.6-plus / qwen3.5-plus | 200,000 | 64,000 |
 | deepseek-chat / deepseek-reasoner / kimi-k2.5 | 256,000 | 128,000 |
 | glm-5 / MiniMax-M2.7 / MiniMax-M2.7-highspeed / MiniMax-M2.5 | 200,000 | 128,000 |

--- a/manager/agent/skills/model-switch/SKILL.md
+++ b/manager/agent/skills/model-switch/SKILL.md
@@ -26,7 +26,10 @@ bash /opt/agentteams/agent/skills/model-switch/scripts/update-manager-model.sh d
 2. Tests the model via `POST /v1/chat/completions` on the AI Gateway — exits with error if unreachable
 3. **OpenClaw**: updates `openclaw.json` model list / primary and `reasoning`
 4. **CoPaw**: updates modern provider `~/.copaw.secret/providers/custom/agentteams-gateway.json` (model-level `generate_kwargs`) + `active_model.json`, and syncs `openclaw.json` `reasoning` / primary (bridge SoT)
-5. Always outputs `RESTART_REQUIRED`
+5. When `AGENTTEAMS_STORAGE_PREFIX` is set, pushes `openclaw.json` to object storage:
+   - always attempts `${AGENTTEAMS_STORAGE_PREFIX}/manager/openclaw.json`
+   - **best-effort** `${AGENTTEAMS_STORAGE_PREFIX}/agents/manager/openclaw.json` (Manager credentials often lack write ACL here; failure is WARN-only). Persistence across Controller reconcile relies on the Controller reading the live workspace and preserving per-model `reasoning`.
+6. Always outputs `RESTART_REQUIRED`
 
 ## After running the script
 
@@ -42,6 +45,8 @@ By default, reasoning (extended thinking) is enabled. To disable it, pass `--no-
 
 - **OpenClaw**: sets `reasoning: false` on the model entry in `openclaw.json`
 - **CoPaw**: sets model-level `generate_kwargs.extra_body.enable_thinking=false` (DashScope Qwen hybrid models), and mirrors `reasoning` onto `openclaw.json`
+
+**Precedence:** the live Manager `openclaw.json` (including this skill’s hot-update) wins over the next Controller regenerate of manager config. `AGENTTEAMS_MODEL_REASONING` / CR defaults alone will **not** flip a model back if the workspace still has the opposite `reasoning` flag — re-run this skill (with or without `--no-reasoning`) so the workspace matches the desired value.
 
 ## On failure
 

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -2,11 +2,17 @@
 # update-manager-model.sh - Hot-update the Manager Agent's model
 #
 # Patches config files in-place based on runtime:
-#   - OpenClaw: ~/manager-workspace/openclaw.json (model list + context window in one file)
-#   - CoPaw: ~/.copaw.secret/providers.json (model list) + ~/.copaw/config.json (context window)
+#   - OpenClaw: openclaw.json (model list + primary + reasoning)
+#   - CoPaw:
+#       ~/.copaw.secret/providers/custom/agentteams-gateway.json (extra_models)
+#       ~/.copaw.secret/providers/active_model.json
+#       ~/.copaw/config.json (context window)
+#       openclaw.json (bridge SoT: reasoning + primary)
 #
-# OpenClaw detects the file change (~300ms) and reloads config automatically.
-# CoPaw may require a restart.
+# --no-reasoning:
+#   OpenClaw → model.reasoning = false
+#   CoPaw    → model generate_kwargs.extra_body.enable_thinking = false
+#              + openclaw.json reasoning = false
 #
 # Usage:
 #   update-manager-model.sh <MODEL_ID> [--context-window <SIZE>] [--no-reasoning]
@@ -15,6 +21,9 @@
 #   update-manager-model.sh claude-sonnet-4-6
 #   update-manager-model.sh my-custom-model --context-window 300000
 #   update-manager-model.sh deepseek-chat --no-reasoning
+#
+# OpenClaw detects the file change (~300ms) and reloads config automatically.
+# CoPaw may require a restart.
 
 set -e
 source /opt/agentteams/scripts/lib/agentteams-env.sh
@@ -29,6 +38,68 @@ _get_max_tokens_param() {
     else
         echo "max_tokens"
     fi
+}
+
+# Patch openclaw.json primary + reasoning (OpenClaw runtime + CoPaw bridge SoT).
+# jq expressions match the historical OpenClaw path; only factored for reuse.
+_patch_openclaw_model() {
+    local openclaw_json="$1"
+    local model_exists
+    model_exists=$(jq --arg model "${MODEL_NAME}" \
+        '[.models.providers["agentteams-gateway"].models[] | select(.id == $model)] | length' \
+        "${openclaw_json}" 2>/dev/null || echo "0")
+
+    if [ "${model_exists}" -gt 0 ]; then
+        jq --arg model "${MODEL_NAME}" \
+           --argjson reasoning "${REASONING}" \
+           '(.models.providers["agentteams-gateway"].models[] | select(.id == $model)).reasoning = $reasoning
+            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
+            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
+           "${openclaw_json}" > "${TMP}" && mv "${TMP}" "${openclaw_json}"
+    else
+        jq --arg model "${MODEL_NAME}" \
+           --argjson ctx "${CTX}" \
+           --argjson max "${MAX}" \
+           --argjson reasoning "${REASONING}" \
+           --argjson input "${INPUT}" \
+           '.models.providers["agentteams-gateway"].models += [{
+               "id": $model,
+               "name": $model,
+               "reasoning": $reasoning,
+               "contextWindow": $ctx,
+               "maxTokens": $max,
+               "input": $input
+             }]
+            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
+            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
+           "${openclaw_json}" > "${TMP}" && mv "${TMP}" "${openclaw_json}"
+    fi
+    echo "${model_exists}"
+}
+
+# Ensure model in modern CoPaw extra_models; set/clear model-level enable_thinking.
+_patch_copaw_model_thinking() {
+    jq --arg model "${MODEL_NAME}" --argjson reasoning "${REASONING}" '
+        .extra_models = (.extra_models // [])
+        | if any(.extra_models[]; .id == $model) then .
+          else .extra_models += [{id: $model, name: $model}]
+          end
+        | .extra_models |= map(
+            if .id != $model then .
+            elif $reasoning == false then
+              .generate_kwargs = (.generate_kwargs // {})
+              | .generate_kwargs.extra_body =
+                  ((.generate_kwargs.extra_body // {}) + {enable_thinking: false})
+            elif .generate_kwargs.extra_body.enable_thinking? == false then
+              del(.generate_kwargs.extra_body.enable_thinking)
+              | if (.generate_kwargs.extra_body // {}) == {} then
+                  del(.generate_kwargs.extra_body) else . end
+              | if (.generate_kwargs // {}) == {} then
+                  del(.generate_kwargs) else . end
+            else .
+            end
+          )
+    ' "${COPAW_CUSTOM_PROVIDER}" > "${TMP}" && mv "${TMP}" "${COPAW_CUSTOM_PROVIDER}"
 }
 
 MODEL_NAME="${1:-}"
@@ -65,11 +136,18 @@ done
 # Determine config files based on runtime
 if [ "${MANAGER_RUNTIME}" = "copaw" ]; then
     CONFIG_FILE="${HOME}/.copaw/config.json"
-    PROVIDERS_FILE="${HOME}/.copaw.secret/providers.json"
-    if [ ! -f "${CONFIG_FILE}" ] || [ ! -f "${PROVIDERS_FILE}" ]; then
-        echo "ERROR: CoPaw config not found"
-        echo "  config.json: ${CONFIG_FILE} ($([ -f "${CONFIG_FILE}" ] && echo 'exists' || echo 'MISSING'))"
-        echo "  providers.json: ${PROVIDERS_FILE} ($([ -f "${PROVIDERS_FILE}" ] && echo 'exists' || echo 'MISSING'))"
+    COPAW_CUSTOM_PROVIDER="${HOME}/.copaw.secret/providers/custom/agentteams-gateway.json"
+    COPAW_ACTIVE_MODEL="${HOME}/.copaw.secret/providers/active_model.json"
+    OPENCLAW_JSON="${HOME}/openclaw.json"
+    [ -f "${OPENCLAW_JSON}" ] || OPENCLAW_JSON="${HOME}/manager-workspace/openclaw.json"
+
+    if [ ! -f "${CONFIG_FILE}" ]; then
+        echo "ERROR: CoPaw config not found: ${CONFIG_FILE}"
+        exit 1
+    fi
+    if [ ! -f "${COPAW_CUSTOM_PROVIDER}" ]; then
+        echo "ERROR: CoPaw provider not found: ${COPAW_CUSTOM_PROVIDER}"
+        echo "This skill expects the modern CoPaw provider layout."
         exit 1
     fi
 else
@@ -81,6 +159,7 @@ else
         echo "ERROR: OpenClaw config not found (checked ~/manager-workspace/openclaw.json and ~/openclaw.json)"
         exit 1
     fi
+    OPENCLAW_JSON="${CONFIG_FILE}"
 fi
 
 # Resolve context window and max tokens
@@ -170,53 +249,36 @@ rm -f /tmp/model-test-resp.json
 TMP=$(mktemp)
 
 if [ "${MANAGER_RUNTIME}" = "copaw" ]; then
-    # ── CoPaw: update providers.json (model list) + config.json (context window) ──
-    # providers.json: .custom_providers["agentteams-gateway"].models + .active_llm.model
-    # config.json: .agents.running.max_input_length
-    jq --arg model "${MODEL_NAME}" \
-       '.custom_providers["agentteams-gateway"].models = [{"id": $model, "name": $model}]
-        | .active_llm.model = $model' \
-       "${PROVIDERS_FILE}" > "${TMP}" && mv "${TMP}" "${PROVIDERS_FILE}"
-    cp "${PROVIDERS_FILE}" "${HOME}/.copaw/providers.json"
+    # Model-level enable_thinking only (no shared provider-level flag).
+    _patch_copaw_model_thinking
+    chmod 600 "${COPAW_CUSTOM_PROVIDER}" 2>/dev/null || true
+
+    mkdir -p "$(dirname "${COPAW_ACTIVE_MODEL}")"
+    jq -n --arg model "${MODEL_NAME}" \
+        '{provider_id: "agentteams-gateway", model: $model}' \
+        > "${TMP}" && mv "${TMP}" "${COPAW_ACTIVE_MODEL}"
+    chmod 600 "${COPAW_ACTIVE_MODEL}" 2>/dev/null || true
 
     jq --argjson ctx "${CTX}" \
        '.agents.running.max_input_length = $ctx' \
        "${CONFIG_FILE}" > "${TMP}" && mv "${TMP}" "${CONFIG_FILE}"
 
-    log "Done. CoPaw model is now: ${MODEL_NAME} (ctx=${CTX})"
+    if [ -f "${OPENCLAW_JSON}" ]; then
+        _patch_openclaw_model "${OPENCLAW_JSON}" >/dev/null
+        log "Synced openclaw.json reasoning=${REASONING} for ${MODEL_NAME}"
+    else
+        log "WARN: openclaw.json not found; provider store updated but bridge SoT was not synced"
+    fi
+
+    log "Done. CoPaw model is now: ${MODEL_NAME} (ctx=${CTX}, reasoning=${REASONING})"
     echo ""
     echo "RESTART_REQUIRED: Restart the CoPaw service to apply the model switch."
 else
     # ── OpenClaw: update openclaw.json ──
-    MODEL_EXISTS=$(jq --arg model "${MODEL_NAME}" \
-        '[.models.providers["agentteams-gateway"].models[] | select(.id == $model)] | length' \
-        "${CONFIG_FILE}" 2>/dev/null || echo "0")
-
+    MODEL_EXISTS=$(_patch_openclaw_model "${OPENCLAW_JSON}")
     if [ "${MODEL_EXISTS}" -gt 0 ]; then
-        jq --arg model "${MODEL_NAME}" \
-           --argjson reasoning "${REASONING}" \
-           '(.models.providers["agentteams-gateway"].models[] | select(.id == $model)).reasoning = $reasoning
-            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
-            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
-           "${CONFIG_FILE}" > "${TMP}" && mv "${TMP}" "${CONFIG_FILE}"
         log "Done. Model is now: ${MODEL_NAME}"
     else
-        jq --arg model "${MODEL_NAME}" \
-           --argjson ctx "${CTX}" \
-           --argjson max "${MAX}" \
-           --argjson reasoning "${REASONING}" \
-           --argjson input "${INPUT}" \
-           '.models.providers["agentteams-gateway"].models += [{
-               "id": $model,
-               "name": $model,
-               "reasoning": $reasoning,
-               "contextWindow": $ctx,
-               "maxTokens": $max,
-               "input": $input
-             }]
-            | .agents.defaults.model.primary = ("agentteams-gateway/" + $model)
-            | .agents.defaults.models["agentteams-gateway/" + $model] = { "alias": $model }' \
-           "${CONFIG_FILE}" > "${TMP}" && mv "${TMP}" "${CONFIG_FILE}"
         log "Done. Model '${MODEL_NAME}' has been added to the models list."
     fi
     echo ""

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -8,6 +8,8 @@
 #       ~/.copaw.secret/providers/active_model.json
 #       ~/.copaw/config.json (context window)
 #       openclaw.json (bridge SoT: reasoning + primary)
+#   When AGENTTEAMS_STORAGE_PREFIX is set, also push openclaw.json to
+#   ${PREFIX}/manager/openclaw.json and ${PREFIX}/agents/manager/openclaw.json.
 #
 # --no-reasoning:
 #   OpenClaw → model.reasoning = false
@@ -100,6 +102,58 @@ _patch_copaw_model_thinking() {
             end
           )
     ' "${COPAW_CUSTOM_PROVIDER}" > "${TMP}" && mv "${TMP}" "${COPAW_CUSTOM_PROVIDER}"
+}
+
+# Push manager openclaw.json to object storage so Remote→Local mirror does not
+# overwrite a fresh local SoT write with a stale remote copy.
+#
+# Two remote keys matter in embedded/k8s installs:
+#   - ${PREFIX}/manager/openclaw.json
+#       Manager Local↔Remote sync (start-manager-agent.sh)
+#   - ${PREFIX}/agents/manager/openclaw.json
+#       Controller mirrors agents/ → agentteams-fs/agents/, and the Manager
+#       workspace is bind-mounted there — a stale agents/manager copy will
+#       overwrite the live openclaw.json within seconds.
+_push_openclaw_to_storage() {
+    local openclaw_json="$1"
+    if [ -z "${AGENTTEAMS_STORAGE_PREFIX:-}" ]; then
+        return 0
+    fi
+    if ! command -v mc >/dev/null 2>&1; then
+        log "WARN: mc not found; skipped push of openclaw.json to storage"
+        return 0
+    fi
+    if ! [ -f "${openclaw_json}" ]; then
+        return 0
+    fi
+    if declare -F ensure_mc_credentials >/dev/null 2>&1; then
+        ensure_mc_credentials 2>/dev/null || true
+    fi
+    local remote
+    local failed=0
+    # manager/ — Manager sync path (expected to succeed when storage is enabled).
+    # agents/manager/ — Controller SoT; often 403 for Manager credentials (best-effort).
+    for remote in \
+        "${AGENTTEAMS_STORAGE_PREFIX}/manager/openclaw.json" \
+        "${AGENTTEAMS_STORAGE_PREFIX}/agents/manager/openclaw.json"
+    do
+        if mc cp "${openclaw_json}" "${remote}" >/dev/null 2>&1; then
+            log "Pushed openclaw.json to ${remote}"
+        else
+            case "${remote}" in
+                */agents/manager/*)
+                    log "WARN: failed to push openclaw.json to ${remote} (often 403; Controller ACL — best-effort)"
+                    ;;
+                *)
+                    log "WARN: failed to push openclaw.json to ${remote}"
+                    ;;
+            esac
+            failed=1
+        fi
+    done
+    if [ "${failed}" -ne 0 ]; then
+        log "WARN: some MinIO pushes failed; persistence relies on live workspace + Controller mergeModelReasoning"
+    fi
 }
 
 MODEL_NAME="${1:-}"
@@ -266,6 +320,7 @@ if [ "${MANAGER_RUNTIME}" = "copaw" ]; then
     if [ -f "${OPENCLAW_JSON}" ]; then
         _patch_openclaw_model "${OPENCLAW_JSON}" >/dev/null
         log "Synced openclaw.json reasoning=${REASONING} for ${MODEL_NAME}"
+        _push_openclaw_to_storage "${OPENCLAW_JSON}"
     else
         log "WARN: openclaw.json not found; provider store updated but bridge SoT was not synced"
     fi
@@ -276,6 +331,7 @@ if [ "${MANAGER_RUNTIME}" = "copaw" ]; then
 else
     # ── OpenClaw: update openclaw.json ──
     MODEL_EXISTS=$(_patch_openclaw_model "${OPENCLAW_JSON}")
+    _push_openclaw_to_storage "${OPENCLAW_JSON}"
     if [ "${MODEL_EXISTS}" -gt 0 ]; then
         log "Done. Model is now: ${MODEL_NAME}"
     else


### PR DESCRIPTION
Fixes #1128

Stacked on #1127 (base: `fix/copaw-model-switch-no-reasoning`). Related write-path fix: #1126 / #1127.

## Summary

- After `model-switch` (or a direct edit) set `openclaw.json` model `reasoning: false`, Controller Manager reconcile regenerated config with default `reasoning: true` and overwrote the shared live workspace / MinIO `agents/manager/openclaw.json` within ~1–4s.
- `PutManagerConfig` / `UpdateManagerGroupAllowFrom` now load existing openclaw **local-first** (live Manager workspace mount), then OSS.
- New `mergeModelReasoning` preserves per-model `reasoning` from the existing config across regenerate (live/hot-update wins over CR / `AGENTTEAMS_MODEL_REASONING` defaults until the workspace is updated again).
- `model-switch` best-effort pushes `openclaw.json` to MinIO `manager/` + `agents/manager/` (the latter often 403 for Manager credentials; WARN-only — persistence relies on Controller merge from live workspace).

## Test plan

- [x] Controller unit tests (Docker `golang:1.25-bookworm`): `TestPutManagerConfig_PreservesModelReasoning`, `TestPutManagerConfig_PrefersLocalReasoningOverStaleOSS`, `TestUpdateManagerGroupAllowFrom_PrefersLocalConfig` (+ existing PutManagerConfig cases)
- [ ] Rebuild / redeploy Controller with this change (script-only Manager update is not enough)

## Notes

- Precedence: live workspace `reasoning` wins over the next Controller regenerate. To flip via CR/env alone, re-run `model-switch` (or edit live openclaw) so the workspace matches.
- Does **not** grant Manager write ACL on `agents/manager/`; that remains Controller SoT.