### PR TITLE
fix(controller): persist team human members

### DIFF
--- a/agentteams-controller/internal/server/resource_handler.go
+++ b/agentteams-controller/internal/server/resource_handler.go
@@ -409,6 +409,9 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 		if req.Admin != nil {
 			team.Spec.Admin = req.Admin
 		}
+		if req.HumanMembers != nil {
+			team.Spec.HumanMembers = req.HumanMembers
+		}
 		if req.PeerMentions != nil {
 			team.Spec.PeerMentions = req.PeerMentions
 		}

--- a/agentteams-controller/internal/server/resource_handler_test.go
+++ b/agentteams-controller/internal/server/resource_handler_test.go
@@ -517,6 +517,9 @@ func TestUpdateTeamMembershipAndHeartbeat(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "alpha-team", Namespace: "default"},
 		Spec: v1beta1.TeamSpec{
 			HeartbeatEvery: "30m",
+			HumanMembers: []v1beta1.TeamMemberSpec{
+				{Name: "alice", Role: "member"},
+			},
 			WorkerMembers: []v1beta1.TeamWorkerRef{
 				{Name: "alpha-lead", Role: "team_leader"},
 				{Name: "alpha-dev", Role: "worker"},
@@ -529,6 +532,7 @@ func TestUpdateTeamMembershipAndHeartbeat(t *testing.T) {
 
 	updateBody := []byte(`{
 		"heartbeatEvery":"45m",
+		"humanMembers":[{"name":"bob","role":"coordinator"}],
 		"workerMembers":[
 			{"name":"alpha-lead","role":"team_leader"},
 			{"name":"alpha-qa","role":"worker"}
@@ -549,6 +553,11 @@ func TestUpdateTeamMembershipAndHeartbeat(t *testing.T) {
 	if updated.Spec.HeartbeatEvery != "45m" {
 		t.Fatalf("heartbeatEvery = %q, want 45m", updated.Spec.HeartbeatEvery)
 	}
+	if got, want := updated.Spec.HumanMembers, []v1beta1.TeamMemberSpec{
+		{Name: "bob", Role: "coordinator"},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("humanMembers = %#v, want %#v", got, want)
+	}
 	if got, want := updated.Spec.WorkerMembers, []v1beta1.TeamWorkerRef{
 		{Name: "alpha-lead", Role: "team_leader"},
 		{Name: "alpha-qa", Role: "worker"},
@@ -565,6 +574,9 @@ func TestUpdateTeamMembershipAndHeartbeat(t *testing.T) {
 	}
 	if !reflect.DeepEqual(resp.WorkerMembers, updated.Spec.WorkerMembers) {
 		t.Fatalf("workerMembers = %#v, want %#v", resp.WorkerMembers, updated.Spec.WorkerMembers)
+	}
+	if !reflect.DeepEqual(resp.HumanMembers, updated.Spec.HumanMembers) {
+		t.Fatalf("humanMembers = %#v, want %#v", resp.HumanMembers, updated.Spec.HumanMembers)
 	}
 }
 

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -11,7 +11,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
-- **Team Human membership updates**: Persist `humanMembers` from Team update requests so declarative apply can add, remove, or change Human member roles.
+- **Team Human membership updates**: Persist `humanMembers` from Team update requests so declarative apply can add, remove, or change Human member roles. ([#1141](https://github.com/agentscope-ai/AgentTeams/pull/1141))
 - **CoPaw Team assignment handoff**: `taskflow(delegate_task)` sends the Worker assignment automatically with `m.mentions` in the Team Room (atomic pending → prepared → assigned state, stable Matrix txn_id for idempotent retries, normalize Worker aliases from the Team roster, refresh Controller-managed runtime context every minute, and reroute assignment replies from non-Team rooms to the Team Room). ([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120), [#1095](https://github.com/agentscope-ai/AgentTeams/pull/1095))
 - **Docker Worker ServiceAccount token rotation**: Project short-lived tokens into per-Worker Docker volumes, refresh the token file atomically without recreating running Workers, and remove the credential volume with the Worker.
 - **Worker port exposure CLI**: Encode `--expose` values as numeric ports and reject invalid or out-of-range inputs before create, update, or apply requests reach the Controller.
@@ -32,7 +32,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug 修复**
 
-- **Team Human 成员更新**：持久化 Team 更新请求中的 `humanMembers`，使声明式 apply 可以添加、移除 Human 成员或调整其角色。
+- **Team Human 成员更新**：持久化 Team 更新请求中的 `humanMembers`，使声明式 apply 可以添加、移除 Human 成员或调整其角色。([#1141](https://github.com/agentscope-ai/AgentTeams/pull/1141))
 - **CoPaw Team 任务分配交接**：由 `taskflow(delegate_task)` 返回必须执行的 Team Room `message` 动作，根据 Team roster 规范化 Worker 别名，每分钟刷新 Controller 管理的运行时上下文，并将非 Team Room 中的任务分配回复重定向到 Team Room。([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120))
 - **Worker 端口暴露 CLI**：将 `--expose` 参数编码为数值端口，并在创建、更新或应用请求到达 Controller 前拒绝无效或越界输入。
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -11,6 +11,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
+- **Team Human membership updates**: Persist `humanMembers` from Team update requests so declarative apply can add, remove, or change Human member roles.
 - **CoPaw Team assignment handoff**: `taskflow(delegate_task)` sends the Worker assignment automatically with `m.mentions` in the Team Room (atomic pending → prepared → assigned state, stable Matrix txn_id for idempotent retries, normalize Worker aliases from the Team roster, refresh Controller-managed runtime context every minute, and reroute assignment replies from non-Team rooms to the Team Room). ([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120), [#1095](https://github.com/agentscope-ai/AgentTeams/pull/1095))
 - **Docker Worker ServiceAccount token rotation**: Project short-lived tokens into per-Worker Docker volumes, refresh the token file atomically without recreating running Workers, and remove the credential volume with the Worker.
 - **Worker port exposure CLI**: Encode `--expose` values as numeric ports and reject invalid or out-of-range inputs before create, update, or apply requests reach the Controller.
@@ -31,6 +32,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug 修复**
 
+- **Team Human 成员更新**：持久化 Team 更新请求中的 `humanMembers`，使声明式 apply 可以添加、移除 Human 成员或调整其角色。
 - **CoPaw Team 任务分配交接**：由 `taskflow(delegate_task)` 返回必须执行的 Team Room `message` 动作，根据 Team roster 规范化 Worker 别名，每分钟刷新 Controller 管理的运行时上下文，并将非 Team Room 中的任务分配回复重定向到 Team Room。([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120))
 - **Worker 端口暴露 CLI**：将 `--expose` 参数编码为数值端口，并在创建、更新或应用请求到达 Controller 前拒绝无效或越界输入。
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))


### PR DESCRIPTION
## Summary

- copy non-nil humanMembers from UpdateTeamRequest into Team.Spec
- cover persisted CR state and the UpdateTeam response
- document the fix in the English and Chinese changelog sections

## Problem

CreateTeam persists humanMembers, and TeamResponse exposes them, but UpdateTeam currently omits the assignment. Declarative apply therefore returns HTTP 200 while retaining stale Human membership and roles.

## Verification

- regression test failed before the fix with alice/member retained instead of bob/coordinator
- targeted TestUpdateTeamMembershipAndHeartbeat passes after the fix
- full Windows unit run passed internal/server and all related packages; three unrelated existing tests require Unix unzip or extensionless mc executables
- GitHub Actions will run the official Linux unit and envtest jobs