### PR TITLE
fix(qwenpaw): propagate model capabilities to QwenPaw worker

### DIFF
--- a/agentteams-controller/internal/agentconfig/generator.go
+++ b/agentteams-controller/internal/agentconfig/generator.go
@@ -366,6 +366,18 @@ func (g *Generator) applyChannelPolicy(config map[string]interface{}, policy *Ch
 	}
 }
 
+// ResolveModelInput returns the input modalities (e.g. ["text", "image"]) for
+// a model, applying the same config overrides as resolveModelSpec. It is the
+// exported capability view used by the runtime-config projector so that
+// managed runtimes (QwenPaw worker) receive model capabilities without having
+// to re-derive them from the model name.
+func (g *Generator) ResolveModelInput(modelName string) []string {
+	if g == nil {
+		return nil
+	}
+	return g.resolveModelSpec(modelName).Input
+}
+
 // resolveModelSpec returns model parameters, applying config overrides.
 func (g *Generator) resolveModelSpec(modelName string) ModelSpec {
 	spec := defaultModelSpec(modelName)

--- a/agentteams-controller/internal/service/deployer_test.go
+++ b/agentteams-controller/internal/service/deployer_test.go
@@ -558,6 +558,11 @@ func TestDeployMemberRuntimeConfigWritesAgentScopedYaml(t *testing.T) {
 	if got := fmt.Sprint(model["gatewayUrl"]); got != "https://aigw.example.com" {
 		t.Fatalf("desired.model.gatewayUrl=%q", got)
 	}
+	// This deployer has no AgentConfig, so capability projection is skipped:
+	// input must be omitted (omitempty) instead of leaking a nil list.
+	if _, ok := model["input"]; ok {
+		t.Fatalf("desired.model.input should be omitted without AgentConfig: %#v", model)
+	}
 	inlineConfig := desired["inlineConfig"].(map[string]any)
 	if got := fmt.Sprint(inlineConfig["identity"]); got != "frontend specialist" {
 		t.Fatalf("desired.inlineConfig.identity=%q", got)
@@ -1335,6 +1340,114 @@ func TestDeployMemberRuntimeConfigRequiresOSSClient(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "OSS") {
 		t.Fatalf("error %q does not mention OSS", err)
+	}
+}
+
+func TestDeployMemberRuntimeConfigProjectsVisionInputForKnownMultimodalModel(t *testing.T) {
+	ctx := context.Background()
+	store := ossfake.NewMemory()
+	deployer := NewDeployer(DeployerConfig{
+		OSS: store,
+		AgentConfig: agentconfig.NewGenerator(agentconfig.Config{
+			DefaultModel: "qwen3.6-plus",
+		}),
+		RuntimeProjection: RuntimeProjectionConfig{
+			StorageProvider: "oss",
+			StorageBucket:   "agentteams-storage",
+			StorageEndpoint: "https://oss.example.com",
+			AIGatewayURL:    "https://aigw.example.com",
+		},
+	})
+
+	err := deployer.DeployMemberRuntimeConfig(ctx, MemberRuntimeConfigDeployRequest{
+		Name:        "worker-a",
+		RuntimeName: "worker-a",
+		Runtime:     "qwenpaw",
+		Role:        "worker",
+		Generation:  3,
+		Spec: v1beta1.WorkerSpec{
+			Model: "qwen3.6-plus",
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeployMemberRuntimeConfig failed: %v", err)
+	}
+
+	got, err := store.GetObject(ctx, "agents/worker-a/runtime/runtime.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(got, &doc); err != nil {
+		t.Fatalf("runtime.yaml is invalid YAML: %v\n%s", err, got)
+	}
+	desired := doc["desired"].(map[string]any)
+	model := desired["model"].(map[string]any)
+	if got := fmt.Sprint(model["model"]); got != "qwen3.6-plus" {
+		t.Fatalf("desired.model.model=%q", got)
+	}
+	input, ok := model["input"].([]any)
+	if !ok {
+		t.Fatalf("desired.model.input missing for vision model: %#v", model)
+	}
+	// qwen3.6-plus is a multimodal preset → input must include image so the
+	// QwenPaw worker registers explicit supports_image/supports_multimodal.
+	hasImage := false
+	for _, item := range input {
+		if fmt.Sprint(item) == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Fatalf("desired.model.input=%v, want [text image]", input)
+	}
+}
+
+func TestDeployMemberRuntimeConfigProjectsTextInputForTextOnlyModel(t *testing.T) {
+	ctx := context.Background()
+	store := ossfake.NewMemory()
+	deployer := NewDeployer(DeployerConfig{
+		OSS: store,
+		AgentConfig: agentconfig.NewGenerator(agentconfig.Config{
+			DefaultModel: "deepseek-chat",
+		}),
+		RuntimeProjection: RuntimeProjectionConfig{
+			StorageProvider: "oss",
+			StorageBucket:   "agentteams-storage",
+			StorageEndpoint: "https://oss.example.com",
+			AIGatewayURL:    "https://aigw.example.com",
+		},
+	})
+
+	err := deployer.DeployMemberRuntimeConfig(ctx, MemberRuntimeConfigDeployRequest{
+		Name:        "worker-textonly",
+		RuntimeName: "worker-textonly",
+		Runtime:     "qwenpaw",
+		Role:        "worker",
+		Generation:  1,
+		Spec: v1beta1.WorkerSpec{
+			Model: "deepseek-chat",
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeployMemberRuntimeConfig failed: %v", err)
+	}
+
+	got, err := store.GetObject(ctx, "agents/worker-textonly/runtime/runtime.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(got, &doc); err != nil {
+		t.Fatalf("runtime.yaml is invalid YAML: %v\n%s", err, got)
+	}
+	model := doc["desired"].(map[string]any)["model"].(map[string]any)
+	input, ok := model["input"].([]any)
+	if !ok {
+		t.Fatalf("text-only model must project an explicit input (not omit it): %#v", model)
+	}
+	if len(input) != 1 || fmt.Sprint(input[0]) != "text" {
+		t.Fatalf("desired.model.input=%v, want [text]", input)
 	}
 }
 

--- a/agentteams-controller/internal/service/deployer_test.go
+++ b/agentteams-controller/internal/service/deployer_test.go
@@ -442,6 +442,11 @@ func TestDeployMemberRuntimeConfigWritesAgentScopedYaml(t *testing.T) {
 	if got := fmt.Sprint(model["gatewayUrl"]); got != "https://aigw.example.com" {
 		t.Fatalf("desired.model.gatewayUrl=%q", got)
 	}
+	// This deployer has no AgentConfig, so capability projection is skipped:
+	// input must be omitted (omitempty) instead of leaking a nil list.
+	if _, ok := model["input"]; ok {
+		t.Fatalf("desired.model.input should be omitted without AgentConfig: %#v", model)
+	}
 	inlineConfig := desired["inlineConfig"].(map[string]any)
 	if got := fmt.Sprint(inlineConfig["identity"]); got != "frontend specialist" {
 		t.Fatalf("desired.inlineConfig.identity=%q", got)
@@ -1219,6 +1224,66 @@ func TestDeployMemberRuntimeConfigRequiresOSSClient(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "OSS") {
 		t.Fatalf("error %q does not mention OSS", err)
+	}
+}
+
+func TestDeployMemberRuntimeConfigProjectsVisionInputForKnownMultimodalModel(t *testing.T) {
+	ctx := context.Background()
+	store := ossfake.NewMemory()
+	deployer := NewDeployer(DeployerConfig{
+		OSS: store,
+		AgentConfig: agentconfig.NewGenerator(agentconfig.Config{
+			DefaultModel: "qwen3.6-plus",
+		}),
+		RuntimeProjection: RuntimeProjectionConfig{
+			StorageProvider: "oss",
+			StorageBucket:   "agentteams-storage",
+			StorageEndpoint: "https://oss.example.com",
+			AIGatewayURL:    "https://aigw.example.com",
+		},
+	})
+
+	err := deployer.DeployMemberRuntimeConfig(ctx, MemberRuntimeConfigDeployRequest{
+		Name:        "worker-a",
+		RuntimeName: "worker-a",
+		Runtime:     "qwenpaw",
+		Role:        "worker",
+		Generation:  3,
+		Spec: v1beta1.WorkerSpec{
+			Model: "qwen3.6-plus",
+		},
+	})
+	if err != nil {
+		t.Fatalf("DeployMemberRuntimeConfig failed: %v", err)
+	}
+
+	got, err := store.GetObject(ctx, "agents/worker-a/runtime/runtime.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(got, &doc); err != nil {
+		t.Fatalf("runtime.yaml is invalid YAML: %v\n%s", err, got)
+	}
+	desired := doc["desired"].(map[string]any)
+	model := desired["model"].(map[string]any)
+	if got := fmt.Sprint(model["model"]); got != "qwen3.6-plus" {
+		t.Fatalf("desired.model.model=%q", got)
+	}
+	input, ok := model["input"].([]any)
+	if !ok {
+		t.Fatalf("desired.model.input missing for vision model: %#v", model)
+	}
+	// qwen3.6-plus is a multimodal preset → input must include image so the
+	// QwenPaw worker registers explicit supports_image/supports_multimodal.
+	hasImage := false
+	for _, item := range input {
+		if fmt.Sprint(item) == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Fatalf("desired.model.input=%v, want [text image]", input)
 	}
 }
 

--- a/agentteams-controller/internal/service/runtime_config.go
+++ b/agentteams-controller/internal/service/runtime_config.go
@@ -81,10 +81,11 @@ type memberRuntimeConfigDesired struct {
 }
 
 type memberRuntimeConfigModel struct {
-	ProviderID string `json:"providerId"`
-	Model      string `json:"model"`
-	GatewayURL string `json:"gatewayUrl,omitempty"`
-	GatewayKey string `json:"gatewayKey,omitempty"`
+	ProviderID string   `json:"providerId"`
+	Model      string   `json:"model"`
+	GatewayURL string   `json:"gatewayUrl,omitempty"`
+	GatewayKey string   `json:"gatewayKey,omitempty"`
+	Input      []string `json:"input,omitempty"` // model input modalities, e.g. ["text", "image"]
 }
 
 type memberRuntimeConfigAgentPackage struct {
@@ -269,6 +270,7 @@ func (d *Deployer) memberRuntimeConfigDocument(req MemberRuntimeConfigDeployRequ
 			Model:      req.Spec.Model,
 			GatewayURL: gatewayURL,
 			GatewayKey: strings.TrimSpace(req.GatewayKey),
+			Input:      d.agentConfig.ResolveModelInput(req.Spec.Model),
 		}
 	}
 	if req.Spec.Package != "" {

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -6,6 +6,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
+- **QwenPaw Worker model capability propagation**: Project the model `input` modalities into `runtime.yaml` and register the gateway provider with explicit `supports_multimodal`/`supports_image`/`supports_video` flags and `probe_source=manual` on the QwenPaw worker. This prevents QwenPaw's self-probe from overwriting controller-injected multimodal capability for reasoning models (whose `reasoning_content` exhausts the probe's token budget, failing the semantic vision check). ([#931](https://github.com/agentscope-ai/AgentTeams/issues/931))
 - **Worker custom skill loading**: Validate and upload Manager-hosted Worker skill files before updating assignments, grant Managers access to Worker storage prefixes, avoid recursive CR updates during reconciliation, keep local/default MinIO paths off unavailable STS, restore Manager MinIO access after Controller restarts, verify uploaded `SKILL.md` files, restore Worker file-sync notifications, and sync plus enable assigned skills in the native QwenPaw workspace.
 - **QwenPaw Manager custom skill hot loading**: Continuously mirror workspace skills into the native QwenPaw workspace, then refresh and enable additions or updates without restarting the Manager.
 - **QwenPaw Manager Skill attachments**: Initialize the Matrix attachment directory at startup so an admin can send a complete Worker Skill ZIP to the Manager for validation and distribution.
@@ -15,6 +16,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug 修复**
 
+- **QwenPaw Worker 模型能力传递**：将模型 `input` 模态投影到 `runtime.yaml`，并在 QwenPaw worker 注册网关 provider 时显式传递 `supports_multimodal`/`supports_image`/`supports_video` 标志和 `probe_source=manual`。这防止 QwenPaw 自探测覆盖 Controller 注入的多模态能力——推理模型（`reasoning_content` 耗尽探测 token 预算、语义视觉校验失败）自探测必然失败。([#931](https://github.com/agentscope-ai/AgentTeams/issues/931))
 - **Worker 自定义 Skill 加载**：更新分配前校验并上传 Manager 托管的 Worker Skill 文件，授予 Manager 对 Worker 存储前缀的访问权限，避免调和期间递归更新 CR，避免本地或默认 MinIO 路径误请求不可用的 STS，Controller 重启后恢复 Manager 的 MinIO 访问并校验已上传的 `SKILL.md`，恢复 Worker 的 file-sync 通知，并在 QwenPaw 原生 workspace 中同步、启用已分配 Skill。
 - **QwenPaw Manager 自定义 Skill 热加载**：持续将 workspace Skill 投影到 QwenPaw 原生 workspace，并自动刷新、启用新增或更新的 Skill，无需重启 Manager。
 - **QwenPaw Manager Skill 附件**：启动时创建 Matrix 附件目录，使管理员可以将完整的 Worker Skill ZIP 发送给 Manager，由其校验并分发。

--- a/qwenpaw/src/qwenpaw_worker/api.py
+++ b/qwenpaw/src/qwenpaw_worker/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -302,12 +302,25 @@ class QwenPawApiClient:
         api_key: str = "",
         provider_name: str = "",
         chat_model: str = "OpenAIChatModel",
+        supports_image: Optional[bool] = None,
+        supports_video: Optional[bool] = None,
+        supports_multimodal: Optional[bool] = None,
+        probe_source: Optional[str] = None,
     ) -> dict[str, Any]:
         providers = self._request("GET", "/api/models")
         provider = next(
             (item for item in providers if item.get("id") == provider_id),
             None,
         )
+        model_payload: dict[str, Any] = {"id": model, "name": model}
+        if supports_image is not None:
+            model_payload["supports_image"] = supports_image
+        if supports_video is not None:
+            model_payload["supports_video"] = supports_video
+        if supports_multimodal is not None:
+            model_payload["supports_multimodal"] = supports_multimodal
+        if probe_source is not None:
+            model_payload["probe_source"] = probe_source
         if provider is None:
             self._request(
                 "POST",
@@ -317,7 +330,7 @@ class QwenPawApiClient:
                     "name": provider_name or provider_id,
                     "default_base_url": base_url,
                     "chat_model": chat_model,
-                    "models": [{"id": model, "name": model}],
+                    "models": [model_payload],
                 },
             )
         else:
@@ -330,7 +343,7 @@ class QwenPawApiClient:
                 self._request(
                     "POST",
                     f"/api/models/{urllib.parse.quote(provider_id, safe='')}/models",
-                    {"id": model, "name": model},
+                    model_payload,
                 )
         config_payload: dict[str, Any] = {"chat_model": chat_model}
         if api_key:

--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -1636,9 +1636,13 @@ class RuntimeUpdater:
             api_key=desired["api_key"],
             provider_name=desired["provider_name"],
             chat_model=desired["chat_model"],
+            supports_image=desired.get("supports_image"),
+            supports_video=desired.get("supports_video"),
+            supports_multimodal=desired.get("supports_multimodal"),
+            probe_source=desired.get("probe_source"),
         )
 
-    def _model_desired_state(self, config: MemberRuntimeConfig) -> Optional[Dict[str, str]]:
+    def _model_desired_state(self, config: MemberRuntimeConfig) -> Optional[Dict[str, Any]]:
         model = config.model
         provider_id = _string(model.get("providerId") or model.get("provider_id") or model.get("provider"))
         model_name = _string(model.get("model") or model.get("name"))
@@ -1661,6 +1665,28 @@ class RuntimeUpdater:
         )
         if not api_key and api_key_env:
             api_key = _string(os.getenv(api_key_env))
+        # input modalities semantics:
+        #   key present -> explicit declaration; probe_source="manual" and the
+        #                  declared value is authoritative. An empty list means
+        #                  "declared text-only" and must NOT fall back to probing.
+        #   key absent  -> the runtime received no declaration; leave capabilities
+        #                  unset (None) so the runtime may probe.
+        if "input" in model:
+            input_modalities = model.get("input") or []
+            if isinstance(input_modalities, str):
+                input_modalities = [input_modalities]
+            supports_image = "image" in input_modalities
+            supports_video = "video" in input_modalities
+            supports_multimodal = bool(supports_image or supports_video)
+            supports_image_val = supports_image
+            supports_video_val = supports_video
+            supports_multimodal_val = supports_multimodal
+            probe_source_val = "manual"
+        else:
+            supports_image_val = None
+            supports_video_val = None
+            supports_multimodal_val = None
+            probe_source_val = None
         return {
             "provider_id": provider_id,
             "model": model_name,
@@ -1672,6 +1698,10 @@ class RuntimeUpdater:
             "chat_model": _string(
                 model.get("chatModel") or model.get("chat_model") or "OpenAIChatModel"
             ),
+            "supports_image": supports_image_val,
+            "supports_video": supports_video_val,
+            "supports_multimodal": supports_multimodal_val,
+            "probe_source": probe_source_val,
         }
 
     def _openai_compatible_base_url(self, base_url: str) -> str:

--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -1540,6 +1540,12 @@ class RuntimeUpdater:
         )
         if not api_key and api_key_env:
             api_key = _string(os.getenv(api_key_env))
+        input_modalities = model.get("input") or []
+        if isinstance(input_modalities, str):
+            input_modalities = [input_modalities]
+        supports_image = "image" in input_modalities
+        supports_video = "video" in input_modalities
+        supports_multimodal = bool(supports_image or supports_video)
         self.api_client.configure_active_model(
             provider_id,
             model_name,
@@ -1547,6 +1553,10 @@ class RuntimeUpdater:
             api_key=api_key,
             provider_name=_string(model.get("providerName") or model.get("provider_name") or provider_id),
             chat_model=_string(model.get("chatModel") or model.get("chat_model") or "OpenAIChatModel"),
+            supports_image=supports_image if input_modalities else None,
+            supports_video=supports_video if input_modalities else None,
+            supports_multimodal=supports_multimodal if input_modalities else None,
+            probe_source="manual" if input_modalities else None,
         )
 
     def _openai_compatible_base_url(self, base_url: str) -> str:

--- a/qwenpaw/tests/test_api.py
+++ b/qwenpaw/tests/test_api.py
@@ -28,6 +28,8 @@ class _ApiHandler(BaseHTTPRequestHandler):
     mcp = {}
     mcp_tools_unavailable = 0
     toggle_conflicts = 0
+    providers = {}
+    active_llm = None
 
     def log_message(self, _format, *_args):
         return
@@ -80,10 +82,29 @@ class _ApiHandler(BaseHTTPRequestHandler):
         if self.path == "/api/agents":
             self._reply(200, {"agents": type(self).agents})
             return
+        if self.path == "/api/models":
+            self._reply(200, list(type(self).providers.values()))
+            return
+        if self.path == "/api/models/active?scope=agent&agent_id=default":
+            self._reply(200, {"active_llm": type(self).active_llm})
+            return
         self._reply(404, {"detail": "missing"})
 
     def do_PUT(self):
         payload = self._payload()
+        if self.path.startswith("/api/models/") and self.path.endswith("/config"):
+            provider_id = self.path.removeprefix("/api/models/").removesuffix("/config")
+            provider = type(self).providers.get(provider_id)
+            if provider is None:
+                self._reply(404, {"detail": "missing"})
+                return
+            provider.update(payload)
+            self._reply(200, provider)
+            return
+        if self.path == "/api/models/active":
+            type(self).active_llm = payload
+            self._reply(200, payload)
+            return
         if self.path == "/api/config/channels/agentteams_matrix":
             type(self).channel = payload
             self._reply(200, payload)
@@ -101,6 +122,27 @@ class _ApiHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         payload = self._payload()
+        if self.path == "/api/models/custom-providers":
+            pid = payload["id"]
+            provider = {
+                "id": pid,
+                "name": payload.get("name", pid),
+                "base_url": payload.get("default_base_url", ""),
+                "models": payload.get("models", []),
+                "extra_models": [],
+            }
+            type(self).providers[pid] = provider
+            self._reply(201, provider)
+            return
+        if self.path.startswith("/api/models/") and self.path.endswith("/models"):
+            provider_id = self.path.removeprefix("/api/models/").removesuffix("/models")
+            provider = type(self).providers.get(provider_id)
+            if provider is None:
+                self._reply(404, {"detail": "missing"})
+                return
+            provider["extra_models"].append(payload)
+            self._reply(201, provider)
+            return
         actions = {
             "/api/access-control/whitelist/add": ("whitelist", True),
             "/api/access-control/whitelist/remove": ("whitelist", False),
@@ -173,6 +215,8 @@ def api_url():
     _ApiHandler.mcp = {}
     _ApiHandler.mcp_tools_unavailable = 0
     _ApiHandler.toggle_conflicts = 0
+    _ApiHandler.providers = {}
+    _ApiHandler.active_llm = None
     server = ThreadingHTTPServer(("127.0.0.1", 0), _ApiHandler)
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -299,3 +343,83 @@ def test_disable_agent_retries_startup_conflict(api_url):
         retry_delay=0,
     ) is True
     assert _ApiHandler.agents[1]["enabled"] is False
+
+
+def test_configure_active_model_creates_provider_with_capabilities(api_url):
+    client = QwenPawApiClient(api_url)
+
+    result = client.configure_active_model(
+        "agentteams-gateway",
+        "qwen3.6-plus",
+        base_url="http://gateway.example.com/v1",
+        api_key="secret",
+        provider_name="AgentTeams Gateway",
+        supports_image=True,
+        supports_video=False,
+        supports_multimodal=True,
+        probe_source="manual",
+    )
+
+    provider = _ApiHandler.providers["agentteams-gateway"]
+    created = provider["models"][0]
+    assert created["id"] == "qwen3.6-plus"
+    assert created["supports_image"] is True
+    assert created["supports_video"] is False
+    assert created["supports_multimodal"] is True
+    assert created["probe_source"] == "manual"
+    assert provider["base_url"] == "http://gateway.example.com/v1"
+    assert _ApiHandler.active_llm == {
+        "provider_id": "agentteams-gateway",
+        "model": "qwen3.6-plus",
+        "scope": "agent",
+        "agent_id": "default",
+    }
+    assert result["active_llm"]["provider_id"] == "agentteams-gateway"
+
+
+def test_configure_active_model_without_capabilities_omits_support_fields(api_url):
+    client = QwenPawApiClient(api_url)
+
+    client.configure_active_model(
+        "agentteams-gateway",
+        "qwen3.6-plus",
+        base_url="http://gateway.example.com/v1",
+        api_key="secret",
+    )
+
+    provider = _ApiHandler.providers["agentteams-gateway"]
+    created = provider["models"][0]
+    assert "supports_image" not in created
+    assert "supports_video" not in created
+    assert "supports_multimodal" not in created
+    assert "probe_source" not in created
+
+
+def test_configure_active_model_existing_provider_appends_model_with_capabilities(
+    api_url,
+):
+    _ApiHandler.providers["agentteams-gateway"] = {
+        "id": "agentteams-gateway",
+        "name": "AgentTeams Gateway",
+        "base_url": "http://gateway.example.com/v1",
+        "models": [],
+        "extra_models": [],
+    }
+    client = QwenPawApiClient(api_url)
+
+    client.configure_active_model(
+        "agentteams-gateway",
+        "qwen3.6-plus",
+        base_url="http://gateway.example.com/v1",
+        api_key="secret",
+        supports_image=True,
+        supports_multimodal=True,
+        probe_source="manual",
+    )
+
+    provider = _ApiHandler.providers["agentteams-gateway"]
+    added = provider["extra_models"][0]
+    assert added["id"] == "qwen3.6-plus"
+    assert added["supports_image"] is True
+    assert added["supports_multimodal"] is True
+    assert added["probe_source"] == "manual"

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -231,6 +231,165 @@ def test_runtime_updater_reconciles_model_mcp_matrix_channel_and_acl_via_api(
     assert not (updater.config.default_workspace_dir / "access_control.json").exists()
 
 
+def test_runtime_updater_passes_model_capabilities_to_active_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QwenPaw worker must forward model input modalities so the provider is
+    registered with explicit supports_* flags instead of triggering a probe
+    that fails for reasoning models (supports_multimodal probe coverage)."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(
+        config=_config(tmp_path),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "qwen3.6-plus",
+                        "gatewayUrl": "https://gateway.example.com",
+                        "input": ["text", "image"],
+                    },
+                },
+            },
+        ),
+    )
+
+    api = updater.api_client
+    assert api.active_model["provider_id"] == "agentteams-gateway"
+    assert api.active_model["model"] == "qwen3.6-plus"
+    assert api.active_model["supports_image"] is True
+    assert api.active_model["supports_video"] is False
+    assert api.active_model["supports_multimodal"] is True
+    assert api.active_model["probe_source"] == "manual"
+
+
+def test_runtime_updater_without_input_keeps_capability_fields_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the runtime config omits model input (older controller), the
+    worker must keep supports_* unset so QwenPaw can still fall back to its
+    probe path instead of hard-coding false."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(
+        config=_config(tmp_path),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "qwen3.6-plus",
+                        "gatewayUrl": "https://gateway.example.com",
+                    },
+                },
+            },
+        ),
+    )
+
+    api = updater.api_client
+    assert api.active_model["provider_id"] == "agentteams-gateway"
+    # _apply_model passes explicit None for unset capabilities; api.py guards
+    # on `is not None` so the payload omits them, letting QwenPaw probe.
+    assert api.active_model["supports_image"] is None
+    assert api.active_model["supports_video"] is None
+    assert api.active_model["supports_multimodal"] is None
+    assert api.active_model["probe_source"] is None
+
+
+def test_runtime_updater_explicit_empty_input_declares_text_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit empty input list declares "text-only" and must NOT fall
+    back to probing: supports_* are set to False and probe_source="manual" so
+    QwenPaw does not run a probe that fails for reasoning models."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(
+        config=_config(tmp_path),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "deepseek-reasoner",
+                        "gatewayUrl": "https://gateway.example.com",
+                        "input": [],
+                    },
+                },
+            },
+        ),
+    )
+
+    api = updater.api_client
+    assert api.active_model["supports_image"] is False
+    assert api.active_model["supports_video"] is False
+    assert api.active_model["supports_multimodal"] is False
+    assert api.active_model["probe_source"] == "manual"
+
+
+def test_runtime_updater_text_only_input_does_not_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """input=["text"] declares a text-only model: capabilities are explicitly
+    False (not None) with probe_source="manual", so no probe is triggered."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(
+        config=_config(tmp_path),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "deepseek-chat",
+                        "gatewayUrl": "https://gateway.example.com",
+                        "input": ["text"],
+                    },
+                },
+            },
+        ),
+    )
+
+    api = updater.api_client
+    assert api.active_model["supports_image"] is False
+    assert api.active_model["supports_video"] is False
+    assert api.active_model["supports_multimodal"] is False
+    assert api.active_model["probe_source"] == "manual"
+
+
 def test_runtime_updater_maps_dingtalk_visibility_and_preserves_empty_secret(
     tmp_path: Path,
 ) -> None:

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -187,6 +187,88 @@ def test_runtime_updater_reconciles_model_mcp_matrix_channel_and_acl_via_api(
     assert not (updater.config.default_workspace_dir / "access_control.json").exists()
 
 
+def test_runtime_updater_passes_model_capabilities_to_active_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QwenPaw worker must forward model input modalities so the provider is
+    registered with explicit supports_* flags instead of triggering a probe
+    that fails for reasoning models (supports_multimodal probe coverage)."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(
+        config=_config(tmp_path),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "qwen3.6-plus",
+                        "gatewayUrl": "https://gateway.example.com",
+                        "input": ["text", "image"],
+                    },
+                },
+            },
+        ),
+    )
+
+    api = updater.api_client
+    assert api.active_model["provider_id"] == "agentteams-gateway"
+    assert api.active_model["model"] == "qwen3.6-plus"
+    assert api.active_model["supports_image"] is True
+    assert api.active_model["supports_video"] is False
+    assert api.active_model["supports_multimodal"] is True
+    assert api.active_model["probe_source"] == "manual"
+
+
+def test_runtime_updater_without_input_keeps_capability_fields_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the runtime config omits model input (older controller), the
+    worker must keep supports_* unset so QwenPaw can still fall back to its
+    probe path instead of hard-coding false."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(
+        config=_config(tmp_path),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "qwen3.6-plus",
+                        "gatewayUrl": "https://gateway.example.com",
+                    },
+                },
+            },
+        ),
+    )
+
+    api = updater.api_client
+    assert api.active_model["provider_id"] == "agentteams-gateway"
+    # _apply_model passes explicit None for unset capabilities; api.py guards
+    # on `is not None` so the payload omits them, letting QwenPaw probe.
+    assert api.active_model["supports_image"] is None
+    assert api.active_model["supports_video"] is None
+    assert api.active_model["supports_multimodal"] is None
+    assert api.active_model["probe_source"] is None
+
+
 def test_runtime_updater_maps_dingtalk_visibility_and_preserves_empty_secret(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1103: propagate model capabilities to the **QwenPaw worker** runtime.

#1103 fixed multimodal capability propagation for the **copaw** runtime only (bridge.py writes providers.json). The QwenPaw worker (introduced by #1077) registers the gateway provider via `configure_active_model()` **without** `supports_*` flags, so QwenPaw's `ProviderManager` self-probes the model. For reasoning models the probe is guaranteed to fail: the model spends its entire `max_tokens` budget on `reasoning_content`, leaves `content` empty, and the semantic vision check ("what color is this image") fails → `supports_multimodal=false` overwrites the controller-injected capability.

This PR closes the QwenPaw path:
1. **Controller**: projects model `input` modalities into `runtime.yaml` (`desired.model.input`) via a new exported `Generator.ResolveModelInput()`.
2. **Worker `update.py`**: reads `input`, derives `supports_image`/`supports_video`/`supports_multimodal`, and passes them to `configure_active_model()`.
3. **Worker `api.py`**: accepts and forwards the flags to the QwenPaw API (`AddModelRequest` already supports them), with `probe_source="manual"` so the self-probe is skipped. For an **already-registered** model entry it converges the stored capability fields (the pinned QwenPaw app has no in-place update endpoint — delete + re-add, only on drift), so existing workers also reach the declared capability instead of keeping their old self-probed state.

## 摘要

#1103 的后续 PR：将模型能力传递给 **QwenPaw worker** 运行时。

#1103 只修复了 **copaw** 运行时的多模态能力传递（bridge.py 写 providers.json）。QwenPaw worker（#1077 引入）通过 `configure_active_model()` 注册网关 provider 时**不带** `supports_*` 标志，因此 QwenPaw 的 `ProviderManager` 会对模型进行自探测。对于推理模型，探测必然失败：模型将全部 `max_tokens` 预算消耗在 `reasoning_content` 上，`content` 为空，语义视觉校验（"这张图是什么颜色"）失败 → `supports_multimodal=false` 覆盖了 Controller 注入的能力。

本 PR 补齐 QwenPaw 路径：
1. **Controller**：通过新增的导出方法 `Generator.ResolveModelInput()`，将模型 `input` 模态投影到 `runtime.yaml`（`desired.model.input`）。
2. **Worker `update.py`**：读取 `input`，推导 `supports_image`/`supports_video`/`supports_multimodal`，传给 `configure_active_model()`。
3. **Worker `api.py`**：接受这些标志并转发给 QwenPaw API（`AddModelRequest` 已支持），同时传 `probe_source="manual"` 跳过自探测。对**已注册**的模型条目，把存储的能力字段收敛到期望值（锁定的 QwenPaw 版本没有就地更新端点——delete + re-add，且仅在有漂移时），已有 Worker 也能达到声明的能力，而不是保留旧的自探测状态。

---

## Why this is an upstream gap (audit)

| Evidence | Finding |
|---|---|
| `git show 2ea02740 --stat` (#1103) | 10 files, all under `agentteams-controller/`, `copaw/`, `install/`, `docs/` — **zero `qwenpaw/` files** |
| `git grep supports_multimodal origin/main -- qwenpaw/` | **zero matches** — QwenPaw worker never consumed the openclaw.json injection (#1103 layer 2) nor bridge.py (#1103 layer 3) |
| `git show fb3a40be:.../api.py` (#1077) | `configure_active_model` shipped with 6 params, no `supports_*` — capability forwarding was missing from day one |
| `memberRuntimeConfigModel` (from #1063) | only `providerId/model/gatewayUrl/gatewayKey` — no `input`, while openclaw.json's `allModelSpecs` already carried it (asymmetry) |

Timeline: shiyiyue1102 reviewed #1103 on 7/29 when only the copaw path existed; #1077 (independent QwenPaw worker runtime) merged 7/31; #1103 merged 8/1 without covering it.

## 为什么这是上游缺口（审计）

| 证据 | 发现 |
|---|---|
| `git show 2ea02740 --stat`（#1103） | 10 个文件全在 `agentteams-controller/`、`copaw/`、`install/`、`docs/` 下 — **qwenpaw/ 目录 0 个文件** |
| `git grep supports_multimodal origin/main -- qwenpaw/` | **零匹配** — QwenPaw worker 从未消费 openclaw.json 注入（#1103 层 2）也未消费 bridge.py（#1103 层 3） |
| `git show fb3a40be:.../api.py`（#1077） | `configure_active_model` 从诞生起就只有 6 个参数、无 `supports_*` — 能力转发从一开始就缺失 |
| `memberRuntimeConfigModel`（#1063 引入） | 只有 `providerId/model/gatewayUrl/gatewayKey` 4 个字段 — 无 `input`，而 openclaw.json 的 `allModelSpecs` 本来就带（不对称） |

时间线：shiyiyue1102 于 7/29 review #1103 时只有 copaw 路径；#1077（独立 QwenPaw worker 运行时）7/31 合入；#1103 8/1 合入时未覆盖它。

---

## Changes

- `agentteams-controller/internal/agentconfig/generator.go`: +12 — `ResolveModelInput()` (nil-safe, reuses `resolveModelSpec`)
- `agentteams-controller/internal/service/runtime_config.go`: `memberRuntimeConfigModel.Input []string` + populate
- `qwenpaw/src/qwenpaw_worker/update.py`: derive + forward capability flags (falls back to `None` when `input` absent → probe path preserved)
- `qwenpaw/src/qwenpaw_worker/api.py`: accept `supports_image/video/multimodal` + `probe_source`, forward in POST payloads (None omitted); existing model entries are reconciled on drift (delete + re-add, display name preserved) and the final readback now verifies the stored capability fields
- Tests: 7 Python (update 2 + api 5, incl. 2 regression tests for the existing-entry reconcile: stale values converge / no-drift is a no-op), 2 Go (vision preset + no-AgentConfig omit)
- `changelog/current.md`: Bug Fixes EN/CN

## 变更

- `agentteams-controller/internal/agentconfig/generator.go`：+12 — `ResolveModelInput()`（nil 安全，复用 `resolveModelSpec`）
- `agentteams-controller/internal/service/runtime_config.go`：`memberRuntimeConfigModel.Input []string` + 填充
- `qwenpaw/src/qwenpaw_worker/update.py`：推导并转发能力标志（`input` 缺失时回退 `None` → 保留探测路径）
- `qwenpaw/src/qwenpaw_worker/api.py`：接受 `supports_image/video/multimodal` + `probe_source`，在 POST payload 中转发（None 省略）；已有模型条目按漂移收敛（delete + re-add，保留展示名），最终 readback 新增能力字段校验
- 测试：7 个 Python（update 2 + api 5，含 2 个已有条目回归：陈旧值收敛 / 无漂移零操作）、2 个 Go（vision 预设 + 无 AgentConfig 省略）
- `changelog/current.md`：Bug Fixes 中英条目

---

## Safety

- `maybe_probe_multimodal` only fires when `supports_multimodal is None` → explicit `true` skips probe
- `update_model_config` does not touch `supports_*` → `PUT /config` never overwrites
- `_apply_default_annotations` only iterates builtin providers, not custom `extra_models`
- Existing-entry reconcile is **delete + re-add, strictly on drift** (the pinned app exposes no in-place capability update: duplicate-id `POST /models` is rejected, `PUT .../config` carries generation params only). Steady state is a no-op — repeated worker updates never churn the entry. The re-add resets per-model `generate_kwargs`/hidden state, which the worker-managed entry does not carry.
- The reconcile is **failure-safe**: the re-add is wrapped in a compensating restore — if it fails after the delete, the original entry is re-posted and verified in the response, so the Worker never ends up without its previously usable model (the next update retries the convergence from the restored state). If the restore also fails, the error names the unregistered model and the recovery action (re-run the worker update; a missing model is re-registered via the add path).

## 安全性

- `maybe_probe_multimodal` 仅在 `supports_multimodal is None` 时触发 → 显式 `true` 跳过探测
- `update_model_config` 不处理 `supports_*` → `PUT /config` 不会覆盖
- `_apply_default_annotations` 只遍历内置 provider，不碰自定义 `extra_models`
- 已有条目协调是 **delete + re-add，严格只在漂移时**（锁定版本无就地能力更新：重复 id 的 `POST /models` 被拒、`PUT .../config` 只带生成参数）。稳态是零操作——重复的 worker 更新不会翻动条目。re-add 会重置 per-model `generate_kwargs`/hidden 状态，worker 管理的条目不携带这些状态。
- 协调过程**失败安全**：re-add 外包一层补偿恢复——若删除后 re-add 失败，原始条目会被重新 POST 并在响应中验证，Worker 不会失去原本可用的模型（下次更新从恢复后的状态重试收敛）。若恢复也失败，错误会指名缺失的模型和恢复动作（重跑 worker 更新；缺失模型会走 add 路径重新注册）。

---

## Test

- `PYTHONPATH=src pytest tests/ --ignore=tests/test_matrix_plugin_edit_mentions.py` → 203 passed, 1 skipped; one **pre-existing** failure `test_integration_workflow_runs_qwenpaw_like_copaw` (fails identically on the unmodified tree in this environment, unrelated to this diff)
- The regression tests are verified against the pre-fix code (stale-value convergence and the two failure-safety tests fail without the fix, pass with it; the rejected-DELETE test pins the pre-existing safe behavior)
- `go test ./internal/service/ ./internal/agentconfig/` → all pass
- `go vet` + `go build ./...` → clean

## 测试

- `PYTHONPATH=src pytest tests/ --ignore=tests/test_matrix_plugin_edit_mentions.py` → 203 passed，1 skipped；一处**预存**失败 `test_integration_workflow_runs_qwenpaw_like_copaw`（未改动的树上同样失败，与本 diff 无关）
- 回归测试已对修复前代码验证过（陈旧值收敛 + 两个失败安全用例在无修复时红、修复后绿；被拒 DELETE 用例钉住既有安全行为）
- `go test ./internal/service/ ./internal/agentconfig/` → 全部通过
- `go vet` + `go build ./...` → 干净

---

Fixes #931 end-to-end (copaw path via #1103 + QwenPaw path via this PR).

## Known limitation (follow-up, not in this PR)

Per-model capability configuration is still controlled by the built-in preset table (15 models) plus global env overrides (`AGENTTEAMS_MODEL_VISION`). Custom/local models not in the presets (e.g. `qwen3.6-27b-fp8`, future `qwen3.8`) default to `vision=false`, and the global env cannot express per-model differences. This PR only fixes the *propagation* layer (the controller now projects the resolved capability into `runtime.yaml` and the QwenPaw worker forwards it). A per-model capability field on the Worker CRD (e.g. `spec.modelCapabilities`) would be the natural follow-up — this PR's `runtime.yaml input` projection is exactly where such a field would land.

## 已知限制（后续 PR，不在本 PR 范围）

Per-model 能力配置仍由内置预设表（15 个模型）加全局 env 覆盖（`AGENTTEAMS_MODEL_VISION`）控制。不在预设表中的自定义/本地模型（如 `qwen3.6-27b-fp8`、未来的 `qwen3.8`）默认为 `vision=false`，且全局 env 无法表达 per-model 差异。本 PR 只修复**传递层**（Controller 现在将解析出的能力投影到 `runtime.yaml`，QwenPaw worker 转发它）。在 Worker CRD 上增加 per-model 能力字段（如 `spec.modelCapabilities`）是自然的后续工作——本 PR 的 `runtime.yaml input` 投影正是该字段的落地点。
