### PR TITLE
fix(initializer): use static service source for IP-based openai-compat base URLs

### DIFF
--- a/agentteams-controller/internal/initializer/initializer.go
+++ b/agentteams-controller/internal/initializer/initializer.go
@@ -3,6 +3,7 @@ package initializer
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -340,15 +341,27 @@ func (i *Initializer) initGatewayRoutes(ctx context.Context) error {
 					if strings.HasPrefix(cfg.OpenAIBaseURL, "http://") {
 						proto = "http"
 					}
-					if err := i.Gateway.EnsureServiceSource(ctx, "openai-compat", host, port, proto); err != nil {
-						logger.Error(err, "failed to register openai-compat service source (non-fatal)")
+					svcName := "openai-compat"
+					svcSuffix := "dns"
+					if net.ParseIP(host) != nil {
+						// Bare IP addresses cannot be registered as DNS-type service sources
+						// (Higress console checkDomain rejects IPs, and Envoy DNS clusters
+						// cannot resolve them); use a static service source instead.
+						svcSuffix = "static"
+						if err := i.Gateway.EnsureStaticServiceSource(ctx, svcName, host, port); err != nil {
+							logger.Error(err, "failed to register openai-compat static service source (non-fatal)")
+						}
+					} else {
+						if err := i.Gateway.EnsureServiceSource(ctx, svcName, host, port, proto); err != nil {
+							logger.Error(err, "failed to register openai-compat service source (non-fatal)")
+						}
 					}
-					// Wait for DNS service source to propagate before creating provider
+					// Wait for service source to propagate before creating provider
 					time.Sleep(2 * time.Second)
 					raw := map[string]interface{}{
 						"agentteamsMode":          true,
 						"openaiCustomUrl":         cfg.OpenAIBaseURL,
-						"openaiCustomServiceName": "openai-compat.dns",
+						"openaiCustomServiceName": svcName + "." + svcSuffix,
 						"openaiCustomServicePort": port,
 					}
 					if err := i.Gateway.EnsureAIProvider(ctx, gateway.AIProviderRequest{
@@ -375,14 +388,24 @@ func (i *Initializer) initGatewayRoutes(ctx context.Context) error {
 					if strings.HasPrefix(cfg.OpenAIBaseURL, "http://") {
 						proto = "http"
 					}
-					if err := i.Gateway.EnsureServiceSource(ctx, provider, host, port, proto); err != nil {
-						logger.Error(err, "failed to register service source for provider (non-fatal)")
+					svcSuffix := "dns"
+					if net.ParseIP(host) != nil {
+						// Bare IP addresses cannot be registered as DNS-type service sources;
+						// use a static service source instead.
+						svcSuffix = "static"
+						if err := i.Gateway.EnsureStaticServiceSource(ctx, provider, host, port); err != nil {
+							logger.Error(err, "failed to register static service source for provider (non-fatal)")
+						}
+					} else {
+						if err := i.Gateway.EnsureServiceSource(ctx, provider, host, port, proto); err != nil {
+							logger.Error(err, "failed to register service source for provider (non-fatal)")
+						}
 					}
 					time.Sleep(2 * time.Second)
 					raw := map[string]interface{}{
 						"agentteamsMode":          true,
 						"openaiCustomUrl":         cfg.OpenAIBaseURL,
-						"openaiCustomServiceName": provider + ".dns",
+						"openaiCustomServiceName": provider + "." + svcSuffix,
 						"openaiCustomServicePort": port,
 					}
 					if err := i.Gateway.EnsureAIProvider(ctx, gateway.AIProviderRequest{


### PR DESCRIPTION
# PR 描述（英文版，用于 GitHub PR）

**Title**: `fix(initializer): use static service source for IP-based openai-compat base URLs`

---

## Summary

Fixes #1057. When `AGENTTEAMS_OPENAI_BASE_URL` uses a bare IP address (e.g. `http://192.168.1.10:3000/v1`), the initializer unconditionally registers a **DNS-type** service source. Two independent failures result:

1. **Higress console rejects bare IPs at validation time** — `ValidateUtil.checkDomain()` uses `DOMAIN_PATTERN = ^(?:(?!-)[a-z0-9]...\.)+[a-z]{2,63}$` which requires a letter TLD; `checkDomain("192.168.1.10")` fails → `ValidationException: serviceSource body is not valid` → the service source is **never created**.
2. The provider's `rawConfigs.openaiCustomServiceName` references `openai-compat.dns`, a cluster that does not exist.

Result: every LLM call fails with `HTTP 503 cluster_not_found` (verified end-to-end on Embedded v1.2.2).

## Changes

`agentteams-controller/internal/initializer/initializer.go`:

- Detect IP hosts with `net.ParseIP(host) != nil` in both the `openai-compat` branch **and** the default provider branch.
- For IP hosts, register a **static** service source (`EnsureStaticServiceSource`, which supports `ip:port` domains and passes `checkIpAddress` validation) and set `rawConfigs.openaiCustomServiceName` to `<provider>.static`.
- For domain hosts, behavior is unchanged (DNS service source + `<provider>.dns`), so existing domain-based setups are fully backward compatible.

## Verification

- [x] `go build ./internal/initializer/` passes (Go 1.22)
- [x] End-to-end on AgentTeams Embedded v1.2.2: after applying the equivalent workaround manually (static service source + `openaiCustomServiceName=openai-compat.static` via console API), all LLM calls return 200. This confirms both the root cause and the fix direction.
- [x] Domain-based flow untouched (regression surface: none — DNS path identical to before).

## Note on prior PRs

- #1090 (closed by author) covered this plus port-stripping and idempotent GET→PUT; this PR is the **minimal** patch for the 503 root cause only, against current `main`. Port-stripping is tracked in #1061 (open).
