### PR TITLE
feat(qwenpaw): upgrade QwenPaw Worker runtime to 2.2.1

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+**What's New**
+
+- **QwenPaw 2.1 Worker runtime upgrade**: bump the QwenPaw Worker image's bundled QwenPaw runtime from 2.0.1 to 2.1.0 (QWENPAW_PIP_SPEC, pyproject dependency, README version contract, and the startup `require_version` readiness check).
+

--- a/plugins/agentteams-matrix-channel/plugin.json
+++ b/plugins/agentteams-matrix-channel/plugin.json
@@ -9,9 +9,9 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "2.0.1",
+  "min_version": "2.2.0",
   "qwenpaw_version": {
-    "min": "2.0.1",
-    "max": "2.1.0"
+    "min": "2.2.0",
+    "max": "2.3.0"
   }
 }

--- a/plugins/agentteams-matrix-channel/plugin.json
+++ b/plugins/agentteams-matrix-channel/plugin.json
@@ -9,9 +9,9 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "2.0.1",
+  "min_version": "2.1.0",
   "qwenpaw_version": {
-    "min": "2.0.1",
-    "max": "2.1.0"
+    "min": "2.1.0",
+    "max": "2.2.0"
   }
 }

--- a/plugins/teamharness/adapters/qwenpaw/plugin.json
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.json
@@ -9,9 +9,9 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "2.0.1",
+  "min_version": "2.2.0",
   "qwenpaw_version": {
-    "min": "2.0.1",
-    "max": "2.1.0"
+    "min": "2.2.0",
+    "max": "2.3.0"
   }
 }

--- a/plugins/teamharness/adapters/qwenpaw/plugin.json
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.json
@@ -9,9 +9,9 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "2.0.1",
+  "min_version": "2.1.0",
   "qwenpaw_version": {
-    "min": "2.0.1",
-    "max": "2.1.0"
+    "min": "2.1.0",
+    "max": "2.2.0"
   }
 }

--- a/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -113,10 +113,10 @@ Dir.mktmpdir("teamharness-qwenpaw-") do |tmp|
       "backend" => "plugin.py"
     },
     "dependencies" => [],
-    "min_version" => "2.0.1",
+    "min_version" => "2.2.0",
     "qwenpaw_version" => {
-      "min" => "2.0.1",
-      "max" => "2.1.0"
+      "min" => "2.2.0",
+      "max" => "2.3.0"
     },
     "meta" => {
       "category" => "teamharness",

--- a/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -113,10 +113,10 @@ Dir.mktmpdir("teamharness-qwenpaw-") do |tmp|
       "backend" => "plugin.py"
     },
     "dependencies" => [],
-    "min_version" => "2.0.1",
+    "min_version" => "2.1.0",
     "qwenpaw_version" => {
-      "min" => "2.0.1",
-      "max" => "2.1.0"
+      "min" => "2.1.0",
+      "max" => "2.2.0"
     },
     "meta" => {
       "category" => "teamharness",

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
@@ -80,9 +80,9 @@ def test_build_qwenpaw_native_plugin_package(tmp_path: Path) -> None:
     assert manifest["version"] == version
     assert manifest["entry"]["backend"] == "plugin.py"
     assert manifest["qwenpaw_version"] == {
-        "min": "2.0.1",
-        "max": "2.1.0",
+        "min": "2.2.0",
+        "max": "2.3.0",
     }
     assert "periodic-sync" not in manifest["meta"]["features"]
 
-    assert manifest["min_version"] == "2.0.1"
+    assert manifest["min_version"] == "2.2.0"

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
@@ -80,9 +80,9 @@ def test_build_qwenpaw_native_plugin_package(tmp_path: Path) -> None:
     assert manifest["version"] == version
     assert manifest["entry"]["backend"] == "plugin.py"
     assert manifest["qwenpaw_version"] == {
-        "min": "2.0.1",
-        "max": "2.1.0",
+        "min": "2.1.0",
+        "max": "2.2.0",
     }
     assert "periodic-sync" not in manifest["meta"]["features"]
 
-    assert manifest["min_version"] == "2.0.1"
+    assert manifest["min_version"] == "2.1.0"

--- a/plugins/tests/workerflow/adapters/qwenpaw/test_workerflow_package.py
+++ b/plugins/tests/workerflow/adapters/qwenpaw/test_workerflow_package.py
@@ -63,7 +63,7 @@ def test_build_qwenpaw_native_workerflow_plugin_package(tmp_path: Path) -> None:
     assert manifest["version"] == version
     assert manifest["entry"]["backend"] == "plugin.py"
     assert manifest["qwenpaw_version"] == {
-        "min": "2.0.1",
-        "max": "2.1.0",
+        "min": "2.2.0",
+        "max": "2.3.0",
     }
     assert "workerflow-mcp" in manifest["meta"]["features"]

--- a/plugins/tests/workerflow/adapters/qwenpaw/test_workerflow_package.py
+++ b/plugins/tests/workerflow/adapters/qwenpaw/test_workerflow_package.py
@@ -63,7 +63,7 @@ def test_build_qwenpaw_native_workerflow_plugin_package(tmp_path: Path) -> None:
     assert manifest["version"] == version
     assert manifest["entry"]["backend"] == "plugin.py"
     assert manifest["qwenpaw_version"] == {
-        "min": "2.0.1",
-        "max": "2.1.0",
+        "min": "2.1.0",
+        "max": "2.2.0",
     }
     assert "workerflow-mcp" in manifest["meta"]["features"]

--- a/plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -105,10 +105,10 @@ Dir.mktmpdir("workerflow-qwenpaw-") do |tmp|
       "backend" => "plugin.py"
     },
     "dependencies" => [],
-    "min_version" => "2.0.1",
+    "min_version" => "2.2.0",
     "qwenpaw_version" => {
-      "min" => "2.0.1",
-      "max" => "2.1.0"
+      "min" => "2.2.0",
+      "max" => "2.3.0"
     },
     "meta" => {
       "category" => "workerflow",

--- a/plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -105,10 +105,10 @@ Dir.mktmpdir("workerflow-qwenpaw-") do |tmp|
       "backend" => "plugin.py"
     },
     "dependencies" => [],
-    "min_version" => "2.0.1",
+    "min_version" => "2.1.0",
     "qwenpaw_version" => {
-      "min" => "2.0.1",
-      "max" => "2.1.0"
+      "min" => "2.1.0",
+      "max" => "2.2.0"
     },
     "meta" => {
       "category" => "workerflow",

--- a/qwenpaw/Dockerfile
+++ b/qwenpaw/Dockerfile
@@ -24,7 +24,7 @@ FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim
 ARG APT_MIRROR=
 ARG PIP_INDEX_URL=https://pypi.org/simple/
 ARG PIP_TIMEOUT=300
-ARG QWENPAW_PIP_SPEC=qwenpaw==2.0.1
+ARG QWENPAW_PIP_SPEC=qwenpaw==2.2.0
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 
 RUN if [ -n "${APT_MIRROR}" ]; then \

--- a/qwenpaw/Dockerfile
+++ b/qwenpaw/Dockerfile
@@ -24,7 +24,7 @@ FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim
 ARG APT_MIRROR=
 ARG PIP_INDEX_URL=https://pypi.org/simple/
 ARG PIP_TIMEOUT=300
-ARG QWENPAW_PIP_SPEC=qwenpaw==2.0.1
+ARG QWENPAW_PIP_SPEC=qwenpaw==2.1.0
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 
 RUN if [ -n "${APT_MIRROR}" ]; then \

--- a/qwenpaw/Dockerfile
+++ b/qwenpaw/Dockerfile
@@ -24,7 +24,7 @@ FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim
 ARG APT_MIRROR=
 ARG PIP_INDEX_URL=https://pypi.org/simple/
 ARG PIP_TIMEOUT=300
-ARG QWENPAW_PIP_SPEC=qwenpaw==2.2.0
+ARG QWENPAW_PIP_SPEC=qwenpaw==2.2.1
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 
 RUN if [ -n "${APT_MIRROR}" ]; then \

--- a/qwenpaw/README.md
+++ b/qwenpaw/README.md
@@ -20,7 +20,7 @@ QwenPaw localhost HTTP API.
 - Prepare the QwenPaw working directory and default workspace.
 - Prepare image-bundled TeamHarness, WorkerFlow, and AgentTeams Matrix plugins.
 - Start the QwenPaw app process.
-- Wait for `/api/version` to report exactly `2.0.1`.
+- Wait for `/api/version` to report exactly `2.2.0`.
 - Apply Agent, Model, MCP, Channel, and ACL desired state through public APIs
   and GET-read it back before starting the update loop.
 - Stop background tasks and the QwenPaw process on shutdown.
@@ -130,7 +130,7 @@ QwenPaw working directory on startup and `runtime.yaml` reapply.
   image build.
 - Keep the QwenPaw plugin ids as `teamharness`, `workerflow`, and
   `agentteams-matrix-channel`.
-- Require QwenPaw `>=2.0.1,<2.1.0` for all three plugins.
+- Require QwenPaw `>=2.2.0,<2.3.0` for all three plugins.
 
 ### 2.2 TeamHarness Assets
 

--- a/qwenpaw/README.md
+++ b/qwenpaw/README.md
@@ -20,7 +20,7 @@ QwenPaw localhost HTTP API.
 - Prepare the QwenPaw working directory and default workspace.
 - Prepare image-bundled TeamHarness, WorkerFlow, and AgentTeams Matrix plugins.
 - Start the QwenPaw app process.
-- Wait for `/api/version` to report exactly `2.0.1`.
+- Wait for `/api/version` to report exactly `2.1.0`.
 - Apply Agent, Model, MCP, Channel, and ACL desired state through public APIs
   and GET-read it back before starting the update loop.
 - Stop background tasks and the QwenPaw process on shutdown.
@@ -130,7 +130,7 @@ QwenPaw working directory on startup and `runtime.yaml` reapply.
   image build.
 - Keep the QwenPaw plugin ids as `teamharness`, `workerflow`, and
   `agentteams-matrix-channel`.
-- Require QwenPaw `>=2.0.1,<2.1.0` for all three plugins.
+- Require QwenPaw `>=2.1.0,<2.2.0` for all three plugins.
 
 ### 2.2 TeamHarness Assets
 

--- a/qwenpaw/pyproject.toml
+++ b/qwenpaw/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "qwenpaw==2.0.1",
+    "qwenpaw==2.2.0",
     "agent-client-protocol>=0.9.0,<0.11.0",
     "markdown-it-py>=3.0",
     "linkify-it-py>=2.0",

--- a/qwenpaw/pyproject.toml
+++ b/qwenpaw/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "qwenpaw==2.0.1",
+    "qwenpaw==2.1.0",
     "agent-client-protocol>=0.9.0,<0.11.0",
     "markdown-it-py>=3.0",
     "linkify-it-py>=2.0",

--- a/qwenpaw/pyproject.toml
+++ b/qwenpaw/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "qwenpaw==2.2.0",
+    "qwenpaw==2.2.1",
     "agent-client-protocol>=0.9.0,<0.11.0",
     "markdown-it-py>=3.0",
     "linkify-it-py>=2.0",

--- a/qwenpaw/scripts/qwenpaw-worker-entrypoint.sh
+++ b/qwenpaw/scripts/qwenpaw-worker-entrypoint.sh
@@ -61,6 +61,16 @@ export QWENPAW_SECRET_DIR="${QWENPAW_SECRET_DIR:-${QWENPAW_WORKING_DIR}.secret}"
 export QWENPAW_RUNNING_IN_CONTAINER=true
 export QWENPAW_LOG_LEVEL="${QWENPAW_LOG_LEVEL:-info}"
 
+# LLM stream stall detection (QwenPaw 2.2.0 #7150): first-content and idle
+# timeouts are read from these env vars at process startup (upstream default
+# 30s each; 0 disables). Local SGLang can starve a stream under concurrent
+# load (8/26 QwenPaw001 false-kill precedent, lesson #386), so AgentTeams
+# defaults both to 300s. Priority: native QWENPAW_LLM_STREAM_* vars (finer
+# per-phase control) > AGENTTEAMS_LLM_STREAM_TIMEOUT_S (single knob) > 300.
+AGENTTEAMS_LLM_STREAM_TIMEOUT_S="${AGENTTEAMS_LLM_STREAM_TIMEOUT_S:-300}"
+export QWENPAW_LLM_STREAM_FIRST_CONTENT_TIMEOUT="${QWENPAW_LLM_STREAM_FIRST_CONTENT_TIMEOUT:-${AGENTTEAMS_LLM_STREAM_TIMEOUT_S}}"
+export QWENPAW_LLM_STREAM_IDLE_TIMEOUT="${QWENPAW_LLM_STREAM_IDLE_TIMEOUT:-${AGENTTEAMS_LLM_STREAM_TIMEOUT_S}}"
+
 # Configure LoongSuite observability plugin if tracing is enabled.
 CMS_TRACES_ENABLED="$(echo "${AGENTTEAMS_CMS_TRACES_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
 if [ "${CMS_TRACES_ENABLED}" = "true" ]; then

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -946,7 +946,7 @@ class Worker:
                     f"qwenpaw app exited before API readiness: {self._process.returncode}",
                 )
             try:
-                await asyncio.to_thread(self.api_client.require_version, "2.0.1")
+                await asyncio.to_thread(self.api_client.require_version, "2.2.0")
                 return
             except Exception as exc:
                 last_error = exc

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -938,7 +938,7 @@ class Worker:
                     f"qwenpaw app exited before API readiness: {self._process.returncode}",
                 )
             try:
-                await asyncio.to_thread(self.api_client.require_version, "2.0.1")
+                await asyncio.to_thread(self.api_client.require_version, "2.1.0")
                 return
             except Exception as exc:
                 last_error = exc

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -946,7 +946,7 @@ class Worker:
                     f"qwenpaw app exited before API readiness: {self._process.returncode}",
                 )
             try:
-                await asyncio.to_thread(self.api_client.require_version, "2.2.0")
+                await asyncio.to_thread(self.api_client.require_version, "2.2.1")
                 return
             except Exception as exc:
                 last_error = exc

--- a/qwenpaw/tests/test_api.py
+++ b/qwenpaw/tests/test_api.py
@@ -46,7 +46,7 @@ class _ApiHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == "/api/version":
-            self._reply(200, {"version": "2.0.1"})
+            self._reply(200, {"version": "2.2.0"})
             return
         if self.path == "/api/config/channels/agentteams_matrix":
             self._reply(

--- a/qwenpaw/tests/test_api.py
+++ b/qwenpaw/tests/test_api.py
@@ -46,7 +46,7 @@ class _ApiHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == "/api/version":
-            self._reply(200, {"version": "2.0.1"})
+            self._reply(200, {"version": "2.1.0"})
             return
         if self.path == "/api/config/channels/agentteams_matrix":
             self._reply(

--- a/qwenpaw/tests/test_api.py
+++ b/qwenpaw/tests/test_api.py
@@ -46,7 +46,7 @@ class _ApiHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == "/api/version":
-            self._reply(200, {"version": "2.2.0"})
+            self._reply(200, {"version": "2.2.1"})
             return
         if self.path == "/api/config/channels/agentteams_matrix":
             self._reply(

--- a/qwenpaw/tests/test_matrix_plugin.py
+++ b/qwenpaw/tests/test_matrix_plugin.py
@@ -25,7 +25,7 @@ def test_matrix_plugin_targets_qwenpaw_2_and_does_not_patch_builtin_matrix():
     dockerfile = (ROOT / "qwenpaw" / "Dockerfile").read_text(encoding="utf-8")
 
     assert manifest["type"] == "channel"
-    assert manifest["qwenpaw_version"] == {"min": "2.0.1", "max": "2.1.0"}
+    assert manifest["qwenpaw_version"] == {"min": "2.2.0", "max": "2.3.0"}
     assert "qwenpaw/app/channels/matrix/channel.py" not in dockerfile
     assert "/opt/agentteams/plugins/agentteams-matrix-channel" in dockerfile
 

--- a/qwenpaw/tests/test_matrix_plugin.py
+++ b/qwenpaw/tests/test_matrix_plugin.py
@@ -25,7 +25,7 @@ def test_matrix_plugin_targets_qwenpaw_2_and_does_not_patch_builtin_matrix():
     dockerfile = (ROOT / "qwenpaw" / "Dockerfile").read_text(encoding="utf-8")
 
     assert manifest["type"] == "channel"
-    assert manifest["qwenpaw_version"] == {"min": "2.0.1", "max": "2.1.0"}
+    assert manifest["qwenpaw_version"] == {"min": "2.1.0", "max": "2.2.0"}
     assert "qwenpaw/app/channels/matrix/channel.py" not in dockerfile
     assert "/opt/agentteams/plugins/agentteams-matrix-channel" in dockerfile
 

--- a/qwenpaw/tests/test_runtime_dependencies.py
+++ b/qwenpaw/tests/test_runtime_dependencies.py
@@ -11,14 +11,14 @@ def test_qwenpaw_acp_api_is_compatible() -> None:
     assert SetSessionModelResponse is not None
 
 
-def test_worker_and_image_target_qwenpaw_2_0_1() -> None:
+def test_worker_and_image_target_qwenpaw_2_2_0() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
 
     assert project["project"]["requires-python"] == ">=3.11,<3.14"
-    assert "qwenpaw==2.0.1" in project["project"]["dependencies"]
+    assert "qwenpaw==2.2.0" in project["project"]["dependencies"]
     assert "agent-client-protocol>=0.9.0,<0.11.0" in project["project"]["dependencies"]
-    assert "ARG QWENPAW_PIP_SPEC=qwenpaw==2.0.1" in dockerfile
+    assert "ARG QWENPAW_PIP_SPEC=qwenpaw==2.2.0" in dockerfile
 
 
 def test_runtime_uses_public_qwenpaw_extension_points_only() -> None:

--- a/qwenpaw/tests/test_runtime_dependencies.py
+++ b/qwenpaw/tests/test_runtime_dependencies.py
@@ -11,14 +11,14 @@ def test_qwenpaw_acp_api_is_compatible() -> None:
     assert SetSessionModelResponse is not None
 
 
-def test_worker_and_image_target_qwenpaw_2_0_1() -> None:
+def test_worker_and_image_target_qwenpaw_2_1_0() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
 
     assert project["project"]["requires-python"] == ">=3.11,<3.14"
-    assert "qwenpaw==2.0.1" in project["project"]["dependencies"]
+    assert "qwenpaw==2.1.0" in project["project"]["dependencies"]
     assert "agent-client-protocol>=0.9.0,<0.11.0" in project["project"]["dependencies"]
-    assert "ARG QWENPAW_PIP_SPEC=qwenpaw==2.0.1" in dockerfile
+    assert "ARG QWENPAW_PIP_SPEC=qwenpaw==2.1.0" in dockerfile
 
 
 def test_runtime_uses_public_qwenpaw_extension_points_only() -> None:

--- a/qwenpaw/tests/test_runtime_dependencies.py
+++ b/qwenpaw/tests/test_runtime_dependencies.py
@@ -16,9 +16,9 @@ def test_worker_and_image_target_qwenpaw_2_2_0() -> None:
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
 
     assert project["project"]["requires-python"] == ">=3.11,<3.14"
-    assert "qwenpaw==2.2.0" in project["project"]["dependencies"]
+    assert "qwenpaw==2.2.1" in project["project"]["dependencies"]
     assert "agent-client-protocol>=0.9.0,<0.11.0" in project["project"]["dependencies"]
-    assert "ARG QWENPAW_PIP_SPEC=qwenpaw==2.2.0" in dockerfile
+    assert "ARG QWENPAW_PIP_SPEC=qwenpaw==2.2.1" in dockerfile
 
 
 def test_runtime_uses_public_qwenpaw_extension_points_only() -> None:


### PR DESCRIPTION
## Summary

Upgrade the QwenPaw Worker image's bundled QwenPaw runtime from 2.0.1 to **2.2.0**. This closes the production defect pinned down by the MHS delivery-delay incident (2026-09-04, sysdev team): qwenpaw 2.0.1 has **no LLM first-token/inter-token stream timeout**, so an upstream stall = permanent turn hang = session frozen for hours with no response and no error. 2.2.0 #7150 fixes this mechanism (30s dual timeout + auto-retry, `ThinkingBlock` counted as meaningful so long thinking isn't killed). No API adaptation is needed — the change is purely version-declaration bumps, verified across three interaction layers against the **v2.2.0** release.

Rebased onto `origin/main` (`acaed255`).

## What's included

1. `qwenpaw/pyproject.toml` — `qwenpaw==2.0.1` → `2.2.0`
2. `qwenpaw/Dockerfile` — `QWENPAW_PIP_SPEC` → `qwenpaw==2.2.0`
3. `qwenpaw/README.md` — wait `/api/version` `2.2.0` + Require `>=2.2.0,<2.3.0`
4. `qwenpaw/src/qwenpaw_worker/worker.py` — startup `require_version("2.2.0")`. `require_version` is a strict `==` check (`if actual != expected: raise`); without this bump the Worker's readiness poll crashes on startup (`actual="2.2.0" != expected="2.0.1"`). (Upstream MCP-identity tracking in this file is preserved; only the version assertion is ours.)
5. `plugins/agentteams-matrix-channel/plugin.json` — `qwenpaw_version` → `>=2.2.0,<2.3.0`
6. `plugins/teamharness/adapters/qwenpaw/plugin.json` — same
7. `plugins/teamharness|workerflow/.../scripts/build-qwenpaw-plugin.rb` — generate plugin manifests with the updated constraint (their `*-qwenpaw.zip` are consumed by `qwenpaw/Dockerfile`). Plugins declare `qwenpaw_version: {min, max}` with left-closed right-open semantics (`>=min,<max`); the old `max` rejects the new version. The upper-bound check is currently temporarily disabled upstream (#6532), but the declaration must be correct for when full range checking is re-enabled
8. `qwenpaw/tests/{test_api,test_runtime_dependencies,test_matrix_plugin}.py` + `plugins/tests/{teamharness,workerflow}/.../test_*_package.py` — sync the version-lock guard assertions (`2.0.1` mock API version / pyproject dependency / Dockerfile `QWENPAW_PIP_SPEC` / plugin manifest constraints / the `test_worker_and_image_target_qwenpaw_2_2_0` guard name) to `2.2.0`/`2.3.0`

No `changelog/current.md` edit: upstream #1182 removed that file and switched to CI-generated release notes (AGENTS.md "Release Notes Policy"), so version-change info is carried by this PR body and auto-generated at release.

## Why 2.2.0 (not 2.1.0)

2.2.0 is the first stable that fixes the stream-stall class of failure that froze sysdev sessions for 3h50m / 7.5h in the MHS incident:

- **Stalled-LLM-stream detection + recovery** (#7150) — 30s first-token and inter-token timeouts with automatic retry; `ThinkingBlock` counts as meaningful output so a long reasoning phase is not mis-killed. This is the direct fix for the production freeze.
- **Spawn timeout structured reporting** (#6869) — default background-task timeout, spawn no longer silently overrides it
- **Model output-limit metadata** (#7386) — discovered model output limits migrated into provider metadata

Known: 2.2.0 has **no** `finish_reason=length` truncation recovery — truncation is handled out-of-band by the protocol's chunked-write path, orthogonal to this upgrade.

## Compatibility (verified against v2.2.0 tag, no adaptation)

190 commits in `v2.1.0..v2.2.0`. The only commit that could touch the model-declaration surface is **#6302** ("unify provider discovery, model metadata, routing, and agent controls", 174 files) — audited: it lands in `providers/` + 9 routers; for the AgentTeams contract the `active model` request/response schema (`ModelSlotRequest`, `active_llm.{provider_id,model}`), `/api/config/channels/*` (channels endpoints unchanged, #6302 only *adds* governance endpoints), and `OpenAIChatModel` (∈ `CUSTOM_CHAT_MODEL_NAMES`, the new validation allow-list) are all unchanged.

- **Plugin Python API** — the 4 in-process symbols the plugins import are unchanged: `HookBase`/`HookResult` (teamharness), `Phase` (8-value enum identical between 2.1/2.2; teamharness uses `PRE_DISPATCH`/`FINALLY`), `reconcile_workspace_manifest(workspace_dir)` + `SkillService(workspace_dir)`/`enable_skill` (workerflow, signatures identical). `qwenpaw_worker` itself is pure HTTP (zero in-process `import qwenpaw`).
- **HTTP API** — all 20 endpoints the worker calls remain: `/api/version` (`_app.py`), `/api/models[/active|custom-providers|{p}/config]`, `/api/config/channels/{ch}`, `/api/agents/{id}/toggle`, `/api/access-control/*`, `/api/mcp/*`, `/api/skills/*`. (`/api/{plugin}/sync` is registered by the teamharness/workerflow plugins themselves; `/api/v1/workers/{n}/{a}` is the Controller's endpoint, not qwenpaw's.)

## Validation

- Version-lock guard tests: **16 passed** — `test_api` (mock `/api/version` → `2.2.0`), `test_runtime_dependencies` (`qwenpaw==2.2.0` + `QWENPAW_PIP_SPEC=qwenpaw==2.2.0` + guard name `..._2_2_0`), `test_matrix_plugin` (`{min: 2.2.0, max: 2.3.0}`) all green
- `test_package`/`test_workerflow_package`: fail locally only on `FileNotFoundError: 'ruby'` (the build script needs Ruby to generate the zip; not present in this sandbox). The generated manifest version (`{min: 2.2.0, max: 2.3.0}` from `build-qwenpaw-plugin.rb`) matches the test assertion exactly — CI images have Ruby, so these pass there

## Status

QwenPaw 2.2.0 is released on PyPI — version declarations match the published version (`qwenpaw==2.2.0`, `require_version("2.2.0")`, plugin constraints `>=2.2.0,<2.3.0`). Rebased onto `origin/main` (`acaed255`), no conflict beyond the expected worker.py MCP-identity merge. **Ready for review.**

Companion PR: #1175 (Manager runtime), independent branch, zero file overlap.

## AgentTeams default for LLM stream stall timeouts: 300s (QwenPaw 2.2.0 #7150)

QwenPaw 2.2.0 adds LLM stream stall detection (#7150) with a first-content and an idle timeout, both defaulting to 30s and read at process startup. In local-LLM deployments (self-hosted SGLang serving a large model under concurrent agent load), a stream can be starved for well over 30s without being dead, so the 30s default false-kills healthy requests — observed twice in our environment (2026-08-26 and 2026-08-28, single-rank SGLang serving a 27B-FP8 model).

This change sets the AgentTeams container default to 300s in the entrypoint/start scripts, with an overridable priority chain:

1. `QWENPAW_LLM_STREAM_FIRST_CONTENT_TIMEOUT` / `QWENPAW_LLM_STREAM_IDLE_TIMEOUT` (native, per-phase, finest control)
2. `AGENTTEAMS_LLM_STREAM_TIMEOUT_S` (single AgentTeams knob)
3. `300` (new default)

Deployments that want the upstream behavior can set `AGENTTEAMS_LLM_STREAM_TIMEOUT_S=30` (or `0` to disable stall detection entirely).

---

将 QwenPaw Worker 镜像内置的 QwenPaw 运行时从 2.0.1 升级到 **2.2.0**。这关闭了 MHS 交付延误事故（2026-09-04，sysdev 团队）钉死的生产缺陷：qwenpaw 2.0.1 **没有 LLM 首 token/间隙流超时**，上游 stream 一 stall = turn 永久挂起 = session 冻结数小时无响应无错误。2.2.0 #7150 修复此机制（30s 双超时 + 自动重试，`ThinkingBlock` 算 meaningful 长思考不误杀）。无需 API 适配——改动纯属版本声明升级，已对照 **v2.2.0** release 在三个交互层验证。

已 rebase 到 `origin/main`（`acaed255`）。

## 改动清单

1. `qwenpaw/pyproject.toml` — `qwenpaw==2.0.1` → `2.2.0`
2. `qwenpaw/Dockerfile` — `QWENPAW_PIP_SPEC` → `qwenpaw==2.2.0`
3. `qwenpaw/README.md` — wait `/api/version` `2.2.0` + Require `>=2.2.0,<2.3.0`
4. `qwenpaw/src/qwenpaw_worker/worker.py` — 启动 `require_version("2.2.0")`。`require_version` 是严格 `==` 检查，漏改则 Worker 就绪轮询启动即崩。（上游在此文件的 MCP-identity 追踪已保留，仅版本断言是我们改的。）
5. `plugins/agentteams-matrix-channel/plugin.json` — `qwenpaw_version` → `>=2.2.0,<2.3.0`
6. `plugins/teamharness/adapters/qwenpaw/plugin.json` — 同上
7. `plugins/teamharness|workerflow/.../scripts/build-qwenpaw-plugin.rb` — 生成 plugin manifest 用更新后的约束（其 `*-qwenpaw.zip` 被 `qwenpaw/Dockerfile` 消费）。插件声明 `qwenpaw_version: {min, max}`（左闭右开 `>=min,<max`），旧 `max` 会拒绝新版本。上限检查上游目前暂时禁用（#6532），但声明必须正确以防恢复检查后失效
8. `qwenpaw/tests/{test_api,test_runtime_dependencies,test_matrix_plugin}.py` + `plugins/tests/{teamharness,workerflow}/.../test_*_package.py` — 同步版本锁守护断言（`2.0.1` mock API 版本 / pyproject 依赖 / Dockerfile `QWENPAW_PIP_SPEC` / 插件 manifest 约束 / `test_worker_and_image_target_qwenpaw_2_2_0` 守护函数名）到 `2.2.0`/`2.3.0`

无 `changelog/current.md` 改动：上游 #1182 删除了该文件，改为 CI 从 merged PRs 自动生成 release notes（AGENTS.md "Release Notes Policy"），版本变更信息由本 PR 描述传达、release 时自动生成。

## 为什么是 2.2.0（不是 2.1.0）

2.2.0 是首个修复 MHS 事故里 stream-stall 类故障（sysdev session 冻结 3h50m / 7.5h）的 stable：

- **Stalled-LLM-stream 检测 + 恢复**（#7150）— 30s 首 token / 间隙超时 + 自动重试；`ThinkingBlock` 算 meaningful 输出，长推理阶段不误杀。这是生产冻结的直接修复。
- **spawn 超时结构化上报**（#6869）— 默认后台任务超时，spawn 不再静默覆盖
- **模型输出上限元数据**（#7386）— 发现的模型输出上限迁移进 provider 元数据

已知：2.2.0 **没有** `finish_reason=length` 截断恢复——截断由协议侧分块写路径兜底，与本次升级正交。

## 兼容性（对照 v2.2.0 tag 验证，无需适配）

`v2.1.0..v2.2.0` 共 190 commit。唯一可能动模型声明面的是 **#6302**（"unify provider discovery, model metadata, routing, and agent controls"，174 文件）——已审计：落在 `providers/` + 9 router；对 AgentTeams 契约，active model 请求/响应 schema（`ModelSlotRequest`、`active_llm.{provider_id,model}`）、`/api/config/channels/*`（channels 端点未动，#6302 只*新增* governance 端点）、`OpenAIChatModel`（∈ `CUSTOM_CHAT_MODEL_NAMES`，新增校验的允许列表）全部不变。

- **插件 Python API** — 三插件进程内 import 的 4 个符号零变化：`HookBase`/`HookResult`（teamharness）、`Phase`（8 值枚举 2.1/2.2 完全一致，teamharness 用 `PRE_DISPATCH`/`FINALLY`）、`reconcile_workspace_manifest(workspace_dir)` + `SkillService(workspace_dir)`/`enable_skill`（workerflow，签名一致）。`qwenpaw_worker` 本身纯 HTTP（零进程内 `import qwenpaw`）。
- **HTTP API** — worker 调用的 20 个端点全部保留：`/api/version`（`_app.py`）、`/api/models[/active|custom-providers|{p}/config]`、`/api/config/channels/{ch}`、`/api/agents/{id}/toggle`、`/api/access-control/*`、`/api/mcp/*`、`/api/skills/*`。（`/api/{plugin}/sync` 是 teamharness/workerflow 插件自注册；`/api/v1/workers/{n}/{a}` 是 Controller 端点，非 qwenpaw。）

## 验证

- 版本锁守护测试：**16 个通过** — `test_api`（mock `/api/version` → `2.2.0`）、`test_runtime_dependencies`（`qwenpaw==2.2.0` + `QWENPAW_PIP_SPEC=qwenpaw==2.2.0` + 守护名 `..._2_2_0`）、`test_matrix_plugin`（`{min: 2.2.0, max: 2.3.0}`）全绿
- `test_package`/`test_workerflow_package`：本地仅因 `FileNotFoundError: 'ruby'` 失败（build 脚本需 Ruby 生成 zip，本沙箱没有）。build 脚本生成的 manifest 版本（`{min: 2.2.0, max: 2.3.0}`）与测试断言完全一致——CI 镜像有 Ruby，那里会过

## 状态

QwenPaw 2.2.0 已发布到 PyPI——版本声明与发布版本一致（`qwenpaw==2.2.0`、`require_version("2.2.0")`、插件约束 `>=2.2.0,<2.3.0`）。已 rebase 到 `origin/main`（`acaed255`），冲突仅 worker.py 的 MCP-identity 合并（预期内）。**可以 review。**

Companion PR：#1175（Manager 运行时），独立分支，零文件重叠。

## LLM 流 stall 超时：AgentTeams 容器默认 300s（QwenPaw 2.2.0 #7150）

2.2.0 新增 LLM 流 stall 检测（#7150）：首内容 / 空闲双超时，均默认 30s，进程启动时读取。本地 LLM 部署（自托管 SGLang 并发服务大模型）下，流可能被并发负载饿死远超 30s 但并未死亡，30s 默认会误杀健康请求——我方环境 8/26、8/28 两度实锤（单 rank SGLang 服务 27B-FP8）。

本变更在容器启动脚本中将 AgentTeams 默认调为 300s，优先级链（可覆盖）：

1. `QWENPAW_LLM_STREAM_FIRST_CONTENT_TIMEOUT` / `QWENPAW_LLM_STREAM_IDLE_TIMEOUT`（原生变量，分相位细调，最细粒度）
2. `AGENTTEAMS_LLM_STREAM_TIMEOUT_S`（AgentTeams 单旋钮）
3. `300`（新默认）

需要上游行为的部署：设 `AGENTTEAMS_LLM_STREAM_TIMEOUT_S=30`（或 `0` 完全禁用 stall 检测）。
