### PR TITLE
fix(controller): preserve embedded AI gateway URL

### DIFF
--- a/agentteams-controller/internal/config/config.go
+++ b/agentteams-controller/internal/config/config.go
@@ -434,12 +434,14 @@ func LoadConfig() *Config {
 
 	// In embedded mode, services (Tuwunel, MinIO) run inside the controller container.
 	// The controller itself uses 127.0.0.1, but child containers (Manager, Workers) must
-	// reach them via the controller's Docker network hostname.
+	// reach Matrix and MinIO via the controller's Docker network hostname. Keep the
+	// configured AI Gateway URL worker-facing: the embedded installer provisions the
+	// aigw-local.agentteams.io network alias, and the gateway route may be exposed
+	// through a different hostname from the controller container.
 	if cfg.KubeMode == "embedded" {
 		if ctrlHost := extractHost(cfg.WorkerEnv.ControllerURL); ctrlHost != "" {
 			cfg.WorkerEnv.MatrixURL = replaceHost(cfg.WorkerEnv.MatrixURL, ctrlHost)
 			cfg.WorkerEnv.FSEndpoint = replaceHost(cfg.WorkerEnv.FSEndpoint, ctrlHost)
-			cfg.WorkerEnv.AIGatewayURL = replaceHost(cfg.WorkerEnv.AIGatewayURL, ctrlHost)
 		}
 	}
 	// S3/MinIO API is never on the Higress HTTP gateway port (8080). Misconfigured

--- a/agentteams-controller/internal/config/config_test.go
+++ b/agentteams-controller/internal/config/config_test.go
@@ -59,6 +59,29 @@ func TestLoadConfigMetricsBindAddrPrefersAgentTeamsEnv(t *testing.T) {
 	}
 }
 
+func TestLoadConfigEmbeddedPreservesWorkerAIGatewayURL(t *testing.T) {
+	t.Setenv("AGENTTEAMS_KUBE_MODE", "embedded")
+	t.Setenv("AGENTTEAMS_CONTROLLER_URL", "http://agentteams-controller:8090")
+	t.Setenv("AGENTTEAMS_MATRIX_URL", "http://127.0.0.1:6167")
+	t.Setenv("AGENTTEAMS_FS_ENDPOINT", "http://127.0.0.1:9000")
+	t.Setenv("AGENTTEAMS_AI_GATEWAY_URL", "http://aigw-local.agentteams.io:8080")
+
+	cfg := LoadConfig()
+
+	if got, want := cfg.WorkerEnv.MatrixURL, "http://agentteams-controller:6167"; got != want {
+		t.Fatalf("WorkerEnv.MatrixURL = %q, want %q", got, want)
+	}
+	if got, want := cfg.WorkerEnv.FSEndpoint, "http://agentteams-controller:9000"; got != want {
+		t.Fatalf("WorkerEnv.FSEndpoint = %q, want %q", got, want)
+	}
+	if got, want := cfg.WorkerEnv.AIGatewayURL, "http://aigw-local.agentteams.io:8080"; got != want {
+		t.Fatalf("WorkerEnv.AIGatewayURL = %q, want %q", got, want)
+	}
+	if got, want := cfg.GatewayConfig().DataPlaneURL, "http://aigw-local.agentteams.io:8080"; got != want {
+		t.Fatalf("GatewayConfig().DataPlaneURL = %q, want %q", got, want)
+	}
+}
+
 func TestLoadConfigAppliesManagerSpec(t *testing.T) {
 	t.Setenv("AGENTTEAMS_MANAGER_SPEC", `{
 		"model":"qwen-max",


### PR DESCRIPTION
## Summary

- Preserve the configured worker-facing `AGENTTEAMS_AI_GATEWAY_URL` in embedded mode.
- Continue rewriting Matrix and MinIO endpoints to the embedded Controller hostname.
- Add a regression test covering the embedded URL contract.

## Why

The embedded config path currently rewrites all child-service URLs to the Controller hostname. That is correct for Matrix and MinIO, but it breaks the AI Gateway URL: the installer provisions `aigw-local.agentteams.io` as the gateway network alias, while the rewritten `agentteams-controller:8080` endpoint returns 404 for Worker model requests. The resolved provider URL is then projected into newly created Managers and Workers.

This was reproduced against AgentTeams `v1.2.2` with a fresh Team/Worker. The direct DeepSeek upstream returned HTTP 200, while the generated Worker URL `http://agentteams-controller:8080` returned 404 for `/v1/models`, `/v1/chat/completions`, and `/v1/responses`. Supplying `http://aigw-local.agentteams.io:8080` at deployment time was overwritten again by the embedded Controller.

Related context: #908. The existing Worker contract documents `AGENTTEAMS_AI_GATEWAY_URL` as the worker-facing gateway endpoint.

## Validation

- `go test ./internal/config ./internal/gateway ./internal/controller`
- `git diff --check`

`go test ./...` was also run on Windows; unrelated environment-dependent tests in `internal/executor` and `internal/oss` require `unzip` and `mc`, which are not installed in that environment.

## Maintainer review

cc @johnlanni @shiyiyue1102 @NingHua-jzp

---

## 中文说明

### 摘要

- 在 embedded 模式下保留面向 Worker 的 `AGENTTEAMS_AI_GATEWAY_URL`。
- Matrix 和 MinIO 仍然继续改写为 embedded Controller 的主机名。
- 增加覆盖 embedded 网关地址契约的回归测试。

### 原因

当前 embedded 配置路径会把所有子服务地址都改写成 Controller 主机名。Matrix 和 MinIO 这样处理是正确的，但 AI Gateway 不应该这样处理：安装器已经为网关配置了 `aigw-local.agentteams.io` 网络别名，而被改写后的 `agentteams-controller:8080` 会让 Worker 的模型请求返回 404。随后解析出的 provider 地址还会继续被投影到新建的 Manager 和 Worker 中。

我们在 AgentTeams `v1.2.2` 上使用全新的 Team/Worker 复现了这个问题。直接访问 DeepSeek 上游的 `/v1/models` 和工具 Chat Completions 请求都返回 HTTP 200；但新 Worker 获得的 `http://agentteams-controller:8080` 访问 `/v1/models`、`/v1/chat/completions` 和 `/v1/responses` 都返回 HTTP 404。在部署层指定正确的 `http://aigw-local.agentteams.io:8080` 后，仍然会被 embedded Controller 覆盖回错误地址。

相关背景见 #908。现有 Worker 契约已经将 `AGENTTEAMS_AI_GATEWAY_URL` 定义为 Worker 面向的网关地址。

### 验证

- `go test ./internal/config ./internal/gateway ./internal/controller`
- `git diff --check`

我们也在 Windows 上执行了 `go test ./...`；其中 `internal/executor` 和 `internal/oss` 的无关环境测试依赖本机安装 `unzip` 和 `mc`，因此在该环境中失败。

### 请维护者确认

@johnlanni @shiyiyue1102 @NingHua-jzp

请确认这个修复是否符合 AgentTeams embedded 模式的网关地址契约，以及是否需要额外覆盖自定义网关域名场景。