### PR TITLE
fix(release): wait for versioned images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,7 +21,39 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Check existing multi-architecture image
+        id: existing
+        env:
+          TARGET: ${{ inputs.target }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          case "$TARGET" in
+            openclaw-base|agentteams-controller) image="$TARGET" ;;
+            *) image="agentteams-${TARGET}" ;;
+          esac
+          ref="${REGISTRY}/${REPO}/${image}:${VERSION}"
+          ready=false
+          if manifest="$(docker buildx imagetools inspect "$ref" --raw)" &&
+            jq -e '
+              any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "amd64") and
+              any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "arm64")
+            ' >/dev/null <<<"$manifest"; then
+            ready=true
+            echo "Reusing $ref: both required architectures exist; skipping build and push."
+          else
+            echo "No complete multi-architecture image verified for $ref; building."
+          fi
+          echo "ready=$ready" >> "$GITHUB_OUTPUT"
+
       - name: Free Up GitHub Actions Ubuntu Runner Disk Space 🔧
+        if: steps.existing.outputs.ready != 'true'
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -32,15 +64,11 @@ jobs:
           swap-storage: true
 
       - uses: actions/checkout@v4
+        if: steps.existing.outputs.ready != 'true'
       - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
+        if: steps.existing.outputs.ready != 'true'
       - name: Build and push
+        if: steps.existing.outputs.ready != 'true'
         env:
           TARGET: ${{ inputs.target }}
           VERSION: ${{ inputs.version }}
@@ -61,7 +89,12 @@ jobs:
 
       - name: Summary
         env:
+          REUSED: ${{ steps.existing.outputs.ready }}
           TARGET: ${{ inputs.target }}
           VERSION: ${{ inputs.version }}
         run: |
-          echo "Built ${TARGET}:${VERSION} for linux/amd64 and linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$REUSED" == true ]]; then
+            echo "Reused ${TARGET}:${VERSION}; build and push skipped (linux/amd64 + linux/arm64)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Built ${TARGET}:${VERSION} for linux/amd64 and linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,15 +40,32 @@ jobs:
           esac
           ref="${REGISTRY}/${REPO}/${image}:${VERSION}"
           ready=false
-          if manifest="$(docker buildx imagetools inspect "$ref" --raw)" &&
-            jq -e '
+          error_file="$(mktemp)"
+          trap 'rm -f "$error_file"' EXIT
+          if manifest="$(docker buildx imagetools inspect "$ref" --raw 2>"$error_file")"; then
+            # A successful command must still return a recognizable manifest.
+            jq -e 'type == "object" and
+              ((.manifests | type) == "array" or
+               ((.config | type) == "object" and (.layers | type) == "array"))
+            ' >/dev/null <<<"$manifest" || {
+              echo "ERROR: invalid manifest returned for $ref"
+              exit 1
+            }
+            if jq -e '
               any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "amd64") and
               any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "arm64")
             ' >/dev/null <<<"$manifest"; then
-            ready=true
-            echo "Reusing $ref: both required architectures exist; skipping build and push."
+              ready=true
+              echo "Reusing $ref: both required architectures exist; skipping build and push."
+            else
+              echo "Required architectures are incomplete for $ref; building."
+            fi
+          elif [[ "$(cat "$error_file")" == "ERROR: ${ref}: not found" ]]; then
+            echo "Image $ref does not exist; building."
           else
-            echo "No complete multi-architecture image verified for $ref; building."
+            cat "$error_file" >&2
+            echo "ERROR: cannot determine whether $ref exists; refusing to rebuild."
+            exit 1
           fi
           echo "ready=$ready" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -9,6 +9,9 @@ on:
       - 'install/agentteams-apply.sh'
       - 'Makefile'
       - '.github/workflows/build.yml'
+      - '.github/workflows/build-image.yml'
+      - '.github/workflows/helm-lint.yml'
+      - 'tests/test-build-workflows.py'
       - '.github/workflows/build-rc.yml'
       - '.github/workflows/build-deepseek-harness.yml'
       - '.github/workflows/release.yml'
@@ -39,6 +42,11 @@ jobs:
 
       - name: Check embedded latest image pulling
         run: bash tests/check-installer-embedded-latest-pull.sh
+
+      - name: Check image build and release workflows
+        run: |
+          python3 -m pip install PyYAML==6.0.3
+          python3 tests/test-build-workflows.py
 
       - name: Check QwenPaw installer runtime options
         run: bash tests/check-installer-qwenpaw-runtime-options.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,54 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Wait for versioned multi-architecture images
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          images=(
+            openclaw-base
+            agentteams-controller
+            agentteams-embedded
+            agentteams-manager
+            agentteams-manager-qwenpaw
+            agentteams-worker
+            agentteams-copaw-worker
+            agentteams-qwenpaw-worker
+            agentteams-hermes-worker
+          )
+          images_ready=0
+          attempt=1
+          max_attempts=80
+
+          while [ "${attempt}" -le "${max_attempts}" ]; do
+            missing=()
+            for image in "${images[@]}"; do
+              ref="${REGISTRY}/${REPO}/${image}:${VERSION}"
+              manifest="$(docker buildx imagetools inspect "${ref}" --raw 2>/dev/null || true)"
+              if ! jq -e '
+                any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "amd64") and
+                any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "arm64")
+              ' >/dev/null 2>&1 <<<"${manifest}"; then
+                missing+=("${image}")
+              fi
+            done
+
+            if [ "${#missing[@]}" -eq 0 ]; then
+              images_ready=1
+              echo "All ${#images[@]} versioned images are ready for ${VERSION}."
+              break
+            fi
+
+            echo "Attempt ${attempt}/${max_attempts}: waiting for ${missing[*]}"
+            attempt=$((attempt + 1))
+            sleep 30
+          done
+
+          if [ "${images_ready}" -ne 1 ]; then
+            echo "ERROR: versioned multi-architecture images are incomplete for ${VERSION}."
+            exit 1
+          fi
+
       - name: Create tag (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/docs/usage/development.md
+++ b/docs/usage/development.md
@@ -239,6 +239,8 @@ Route, consumer, and MCP server bootstrap for **embedded** stacks is owned by th
 
 `build.yml` runs each image on a separate runner. OpenClaw Base, Controller, and QwenPaw Worker start independently. Embedded, QwenPaw Manager, CoPaw Worker, and Hermes Worker wait for Controller; OpenClaw Manager and Worker wait for both Base and Controller. Each image still builds amd64 and arm64 using QEMU.
 
+Before building, each job inspects its version tag. If both linux/amd64 and linux/arm64 already exist, it succeeds without building or pushing; downstream jobs continue normally. Missing, incomplete, or unverifiable manifests trigger a build. Reuse is based on the tag and architectures, not source commit identity, and also applies to `latest`. Reusing a version does not update the `latest` alias. Use a new version to build changed source.
+
 A version tag starts the full build, then calls `release.yml` only after every image job succeeds. Release verifies all nine versioned multi-architecture manifests before publishing. There is no fixed polling window while images are building.
 
 For manual builds, select **Build Images**, set `version`, and set `targets` to `all` or exact space-separated target names. Required Base/Controller dependencies are built automatically. Manual builds do not publish a GitHub Release. To publish manually, first finish the full build, then run **Release** with the same version and source ref. If publication fails after the images succeed, rerun the failed release job.

--- a/docs/usage/development.md
+++ b/docs/usage/development.md
@@ -239,7 +239,7 @@ Route, consumer, and MCP server bootstrap for **embedded** stacks is owned by th
 
 `build.yml` runs each image on a separate runner. OpenClaw Base, Controller, and QwenPaw Worker start independently. Embedded, QwenPaw Manager, CoPaw Worker, and Hermes Worker wait for Controller; OpenClaw Manager and Worker wait for both Base and Controller. Each image still builds amd64 and arm64 using QEMU.
 
-Before building, each job inspects its version tag. If both linux/amd64 and linux/arm64 already exist, it succeeds without building or pushing; downstream jobs continue normally. Missing, incomplete, or unverifiable manifests trigger a build. Reuse is based on the tag and architectures, not source commit identity, and also applies to `latest`. Reusing a version does not update the `latest` alias. Use a new version to build changed source.
+Before building, each job inspects its version tag. If both linux/amd64 and linux/arm64 already exist, it succeeds without building or pushing; downstream jobs continue normally. Only an explicit image-not-found response or a valid manifest missing a required architecture triggers a build. Query failures (including authentication, rate limiting, and network errors) or invalid responses fail the job without rebuilding. Reuse is based on the tag and architectures, not source commit identity, and also applies to `latest`. Reusing a version does not update the `latest` alias. Use a new version to build changed source.
 
 A version tag starts the full build, then calls `release.yml` only after every image job succeeds. Release verifies all nine versioned multi-architecture manifests before publishing. There is no fixed polling window while images are building.
 

--- a/docs/zh-cn/usage/development.md
+++ b/docs/zh-cn/usage/development.md
@@ -239,6 +239,8 @@ Agent 行为由 Markdown 文件定义，而非代码：
 
 `build.yml` 为每个镜像分配独立 runner。OpenClaw Base、Controller、QwenPaw Worker 独立启动；Embedded、QwenPaw Manager、CoPaw Worker、Hermes Worker 等待 Controller；OpenClaw Manager 和 Worker 等待 Base 与 Controller。每个镜像仍通过 QEMU 构建 amd64 和 arm64。
 
+每个任务在构建前检查目标版本 tag：若 linux/amd64、linux/arm64 均已存在，则直接成功，跳过构建和推送，下游任务继续执行。镜像不存在、架构不完整或无法确认时执行构建。复用只校验 tag 和架构，不比对源码 commit；`latest` 也适用。复用版本镜像不会更新 `latest` 别名；修改源码后应使用新版本构建。
+
 版本 tag 触发全量构建，全部镜像任务成功后才调用 `release.yml`。Release 校验全部九个版本镜像的双架构 manifest 后发布，不再使用固定轮询窗口等待构建。
 
 手动构建时选择 **Build Images**，填写 `version`，将 `targets` 设为 `all` 或以空格分隔的准确目标名称；所需的 Base/Controller 依赖会自动构建。手动构建不会发布 GitHub Release。手动发布需先完成全量构建，再用相同版本和源码 ref 运行 **Release**。若镜像成功后发布失败，可仅重跑失败的发布任务。

--- a/docs/zh-cn/usage/development.md
+++ b/docs/zh-cn/usage/development.md
@@ -239,7 +239,7 @@ Agent 行为由 Markdown 文件定义，而非代码：
 
 `build.yml` 为每个镜像分配独立 runner。OpenClaw Base、Controller、QwenPaw Worker 独立启动；Embedded、QwenPaw Manager、CoPaw Worker、Hermes Worker 等待 Controller；OpenClaw Manager 和 Worker 等待 Base 与 Controller。每个镜像仍通过 QEMU 构建 amd64 和 arm64。
 
-每个任务在构建前检查目标版本 tag：若 linux/amd64、linux/arm64 均已存在，则直接成功，跳过构建和推送，下游任务继续执行。镜像不存在、架构不完整或无法确认时执行构建。复用只校验 tag 和架构，不比对源码 commit；`latest` 也适用。复用版本镜像不会更新 `latest` 别名；修改源码后应使用新版本构建。
+每个任务在构建前检查目标版本 tag：若 linux/amd64、linux/arm64 均已存在，则直接成功，跳过构建和推送，下游任务继续执行。仅在明确返回镜像不存在，或有效 manifest 缺少所需架构时执行构建。查询失败（认证、限流、网络错误等）或响应无效时直接失败，不触发重建。复用只校验 tag 和架构，不比对源码 commit；`latest` 也适用。复用版本镜像不会更新 `latest` 别名；修改源码后应使用新版本构建。
 
 版本 tag 触发全量构建，全部镜像任务成功后才调用 `release.yml`。Release 校验全部九个版本镜像的双架构 manifest 后发布，不再使用固定轮询窗口等待构建。
 

--- a/tests/check-installer-qwenpaw-runtime-options.sh
+++ b/tests/check-installer-qwenpaw-runtime-options.sh
@@ -8,7 +8,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASH_INSTALLER="${ROOT_DIR}/install/agentteams-install.sh"
 POWERSHELL_INSTALLER="${ROOT_DIR}/install/agentteams-install.ps1"
 INTEGRATION_WORKFLOW="${ROOT_DIR}/.github/workflows/test-integration.yml"
-BUILD_WORKFLOW="${ROOT_DIR}/.github/workflows/build.yml"
 RELEASE_WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
 
 fail() {
@@ -94,8 +93,7 @@ powershell_worker_images="$(sed -n '/\$workerImages = @(/,/^    )/p' "${POWERSHE
 grep -F 'QWENPAW_WORKER_IMAGE' <<<"${powershell_worker_images}" | grep -Eqv '^[[:space:]]*#' ||
     fail "PowerShell installer must pull the published QwenPaw Worker image"
 
-grep -F 'echo "targets=' "${BUILD_WORKFLOW}" | grep -F 'qwenpaw-worker' >/dev/null ||
-    fail "Tag-triggered image builds must publish qwenpaw-worker"
+# Tag-triggered image selection is exercised in test-build-workflows.py.
 grep -Fq 'docker pull ${REGISTRY}/${REPO}/agentteams-qwenpaw-worker:${VERSION}' \
     "${RELEASE_WORKFLOW}" ||
     fail "Release notes must list the versioned QwenPaw Worker image"

--- a/tests/test-build-workflows.py
+++ b/tests/test-build-workflows.py
@@ -97,6 +97,32 @@ class BuildWorkflowTests(unittest.TestCase):
                 self.assertNotIn('Building + pushing agentteams-controller', result.stdout)
                 self.assertIn('AGENTTEAMS_CONTROLLER_IMAGE=example.test/agentteams/agentteams-controller:v1.2.3', result.stdout)
 
+    def test_existing_image_skips_only_when_both_architectures_are_verified(self):
+        steps = IMAGE['jobs']['build']['steps']
+        check = next(s for s in steps if s.get('id') == 'existing')
+        build = next(s for s in steps if s.get('name') == 'Build and push')
+        self.assertEqual(build['if'], "steps.existing.outputs.ready != 'true'")
+        both = json.dumps({'manifests': [{'platform': {'os': 'linux', 'architecture': arch}} for arch in ['amd64', 'arm64']]})
+        single = json.dumps({'manifests': [{'platform': {'os': 'linux', 'architecture': 'amd64'}}]})
+        with tempfile.TemporaryDirectory() as directory:
+            stub = Path(directory) / 'docker'
+            stub.write_text('#!/bin/bash\nprintf "%s" "$4" > "$IMAGE_LOG"\nprintf "%s" "$MANIFEST"\nexit "$STATUS"\n')
+            stub.chmod(0o755)
+            for target in set(BUILD['jobs']) - {'prepare', 'release'}:
+                for manifest, status, ready in [(both, '0', 'true'), (single, '0', 'false'), ('', '1', 'false'), ('not-json', '0', 'false'), ('', '0', 'false')]:
+                    with self.subTest(target=target, status=status, manifest=manifest):
+                        output = Path(directory) / 'output'
+                        output.write_text('')
+                        log = Path(directory) / 'image'
+                        result = subprocess.run(['bash', '-e', '-o', 'pipefail', '-c', check['run']], capture_output=True, text=True,
+                                                env={**os.environ, 'PATH': directory + ':' + os.environ['PATH'],
+                                                     'TARGET': target, 'VERSION': 'v1.2.3', 'REGISTRY': 'example.test', 'REPO': 'agentteams',
+                                                     'MANIFEST': manifest, 'STATUS': status, 'GITHUB_OUTPUT': str(output), 'IMAGE_LOG': str(log)})
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                        self.assertEqual(output.read_text(), 'ready=' + ready + '\n')
+                        image = target if target in ['openclaw-base', 'agentteams-controller'] else 'agentteams-' + target
+                        self.assertEqual(log.read_text(), f'example.test/agentteams/{image}:v1.2.3')
+
     def test_release_gate_rejects_missing_or_single_arch_images(self):
         script = next(s['run'] for s in RELEASE['jobs']['release']['steps'] if s.get('name') == 'Verify versioned multi-architecture images')
         both = json.dumps({'manifests': [{'platform': {'os': 'linux', 'architecture': arch}} for arch in ['amd64', 'arm64']]})

--- a/tests/test-build-workflows.py
+++ b/tests/test-build-workflows.py
@@ -106,10 +106,18 @@ class BuildWorkflowTests(unittest.TestCase):
         single = json.dumps({'manifests': [{'platform': {'os': 'linux', 'architecture': 'amd64'}}]})
         with tempfile.TemporaryDirectory() as directory:
             stub = Path(directory) / 'docker'
-            stub.write_text('#!/bin/bash\nprintf "%s" "$4" > "$IMAGE_LOG"\nprintf "%s" "$MANIFEST"\nexit "$STATUS"\n')
+            stub.write_text('#!/bin/bash\nprintf "%s" "$4" > "$IMAGE_LOG"\nprintf "%s" "$MANIFEST"\nif [[ "$ERROR" == missing ]]; then printf "ERROR: %s: not found\\n" "$4" >&2; else printf "%s" "$ERROR" >&2; fi\nexit "$STATUS"\n')
             stub.chmod(0o755)
             for target in set(BUILD['jobs']) - {'prepare', 'release'}:
-                for manifest, status, ready in [(both, '0', 'true'), (single, '0', 'false'), ('', '1', 'false'), ('not-json', '0', 'false'), ('', '0', 'false')]:
+                for manifest, status, error, ready in [
+                    (both, '0', '', 'true'), (single, '0', '', 'false'),
+                    ('', '1', 'missing', 'false'),
+                    ('', '1', 'ERROR: timeout', None),
+                    ('', '1', 'ERROR: 401 Unauthorized', None),
+                    ('', '1', 'ERROR: 429 Too Many Requests', None),
+                    ('', '1', 'ERROR: proxy: not found', None),
+                    ('not-json', '0', '', None), ('', '0', '', None),
+                ]:
                     with self.subTest(target=target, status=status, manifest=manifest):
                         output = Path(directory) / 'output'
                         output.write_text('')
@@ -117,9 +125,9 @@ class BuildWorkflowTests(unittest.TestCase):
                         result = subprocess.run(['bash', '-e', '-o', 'pipefail', '-c', check['run']], capture_output=True, text=True,
                                                 env={**os.environ, 'PATH': directory + ':' + os.environ['PATH'],
                                                      'TARGET': target, 'VERSION': 'v1.2.3', 'REGISTRY': 'example.test', 'REPO': 'agentteams',
-                                                     'MANIFEST': manifest, 'STATUS': status, 'GITHUB_OUTPUT': str(output), 'IMAGE_LOG': str(log)})
-                        self.assertEqual(result.returncode, 0, result.stderr)
-                        self.assertEqual(output.read_text(), 'ready=' + ready + '\n')
+                                                     'MANIFEST': manifest, 'STATUS': status, 'ERROR': error, 'GITHUB_OUTPUT': str(output), 'IMAGE_LOG': str(log)})
+                        self.assertEqual(result.returncode == 0, ready is not None, result.stderr)
+                        self.assertEqual(output.read_text(), 'ready=' + ready + '\n' if ready is not None else '')
                         image = target if target in ['openclaw-base', 'agentteams-controller'] else 'agentteams-' + target
                         self.assertEqual(log.read_text(), f'example.test/agentteams/{image}:v1.2.3')
 

--- a/tests/test-build-workflows.py
+++ b/tests/test-build-workflows.py
@@ -40,6 +40,11 @@ class BuildWorkflowTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(values['version'], 'v1.2.3')
         selected = set(json.loads(values['targets']))
+        self.assertEqual(selected, {
+            'openclaw-base', 'agentteams-controller', 'embedded',
+            'manager', 'manager-qwenpaw', 'worker', 'copaw-worker',
+            'hermes-worker', 'qwenpaw-worker',
+        })
         self.assertEqual(selected, set(BUILD['jobs']) - {'prepare', 'release'})
         self.assertEqual(set(BUILD['jobs']['release']['needs']), selected | {'prepare'})
 


### PR DESCRIPTION
## Summary

- gate GitHub Release publication on all versioned release images being present
- require both `linux/amd64` and `linux/arm64` for every image
- fail closed when image building is incomplete instead of publishing an installable release early

## Why

Tag pushes currently start `Build Images` and `Release` independently. The Release can therefore publish its installer and quick-start instructions before the matching images exist. This change keeps the existing parallel trigger but prevents the GitHub Release from becoming the latest stable version until all nine image manifests are complete.

Manual `workflow_dispatch` releases now also require images to be built first, which avoids relying on a workflow-created tag to trigger the image workflow.

## Validation

- `git diff --check`
- workflow YAML parse
- extracted gate shell passes `bash -n`
- two-platform jq predicate accepts a valid manifest and rejects an amd64-only manifest
- live read-only verification against all nine `v1.2.2` registry manifests
