### PR TITLE
feat(controller): add human update endpoint (PUT /api/v1/humans/{name})

### DIFF
--- a/agentteams-controller/internal/auth/authorizer_test.go
+++ b/agentteams-controller/internal/auth/authorizer_test.go
@@ -71,6 +71,31 @@ func TestAuthorizer_HumanScoped(t *testing.T) {
 	}
 }
 
+// TestAuthorizer_HumanUpdateAdminOnly guards the human permission-update
+// boundary: only admin/manager may PUT /api/v1/humans/{name}.
+func TestAuthorizer_HumanUpdateAdminOnly(t *testing.T) {
+	az := NewAuthorizer()
+	allowed := []CallerIdentity{
+		{Role: RoleAdmin, Username: "admin"},
+		{Role: RoleManager, Username: "manager"},
+	}
+	for i := range allowed {
+		if err := az.Authorize(&allowed[i], AuthzRequest{Action: ActionUpdate, ResourceKind: "human", ResourceName: "maizong"}); err != nil {
+			t.Errorf("%s should be allowed to update humans, got: %v", allowed[i].Role, err)
+		}
+	}
+	denied := []CallerIdentity{
+		{Role: RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"},
+		{Role: RoleHuman, Username: "maizong", Teams: []string{"market-team"}},
+		{Role: RoleWorker, Username: "alpha-dev", Team: "alpha-team"},
+	}
+	for i := range denied {
+		if err := az.Authorize(&denied[i], AuthzRequest{Action: ActionUpdate, ResourceKind: "human", ResourceName: "maizong"}); err == nil {
+			t.Errorf("%s must be denied updating humans", denied[i].Role)
+		}
+	}
+}
+
 func TestAuthorizer_TeamLeaderOwnTeam(t *testing.T) {
 	az := NewAuthorizer()
 	caller := &CallerIdentity{Role: RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"}

--- a/agentteams-controller/internal/server/http.go
+++ b/agentteams-controller/internal/server/http.go
@@ -88,6 +88,7 @@ func NewHTTPServer(addr string, deps ServerDeps) *HTTPServer {
 	mux.Handle("POST /api/v1/humans", mw.RequireAuthz(authpkg.ActionCreate, "human", nil)(http.HandlerFunc(rh.CreateHuman)))
 	mux.Handle("GET /api/v1/humans", mw.RequireAuthz(authpkg.ActionList, "human", nil)(http.HandlerFunc(rh.ListHumans)))
 	mux.Handle("GET /api/v1/humans/{name}", mw.RequireAuthz(authpkg.ActionGet, "human", nameFn)(http.HandlerFunc(rh.GetHuman)))
+	mux.Handle("PUT /api/v1/humans/{name}", mw.RequireAuthz(authpkg.ActionUpdate, "human", nameFn)(http.HandlerFunc(rh.UpdateHuman)))
 	mux.Handle("DELETE /api/v1/humans/{name}", mw.RequireAuthz(authpkg.ActionDelete, "human", nameFn)(http.HandlerFunc(rh.DeleteHuman)))
 
 	// Managers

--- a/agentteams-controller/internal/server/resource_handler.go
+++ b/agentteams-controller/internal/server/resource_handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -554,6 +555,132 @@ func (h *ResourceHandler) GetHuman(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, humanToResponse(&human))
+}
+
+func (h *ResourceHandler) UpdateHuman(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "human name is required")
+		return
+	}
+
+	var req UpdateHumanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	for attempt := 0; attempt < k8sUpdateMaxRetries; attempt++ {
+		var human v1beta1.Human
+		if err := h.client.Get(ctx, client.ObjectKey{Name: name, Namespace: h.namespace}, &human); err != nil {
+			writeK8sError(w, "get human for update", err)
+			return
+		}
+
+		if req.PermissionLevel != nil && (*req.PermissionLevel < 1 || *req.PermissionLevel > 3) {
+			httputil.WriteError(w, http.StatusBadRequest, "permissionLevel must be 1 (admin), 2 (team), or 3 (worker)")
+			return
+		}
+		if err := h.validateHumanReferences(ctx, req.AccessibleTeams, req.AccessibleWorkers); err != nil {
+			if errors.Is(err, errDanglingReference) {
+				httputil.WriteError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			// Backend lookup failure (K8s API timeout, permission, or
+			// service error): a server problem, not a client error.
+			writeK8sError(w, "validate human references", err)
+			return
+		}
+
+		if req.DisplayName != nil {
+			human.Spec.DisplayName = *req.DisplayName
+		}
+		if req.Email != nil {
+			human.Spec.Email = *req.Email
+		}
+		if req.PermissionLevel != nil {
+			human.Spec.PermissionLevel = *req.PermissionLevel
+		}
+		if req.AccessibleTeams != nil {
+			human.Spec.AccessibleTeams = *req.AccessibleTeams
+		}
+		if req.AccessibleWorkers != nil {
+			human.Spec.AccessibleWorkers = *req.AccessibleWorkers
+		}
+		if req.Note != nil {
+			human.Spec.Note = *req.Note
+		}
+
+		if err := h.client.Update(ctx, &human); err != nil {
+			if apierrors.IsConflict(err) && attempt+1 < k8sUpdateMaxRetries {
+				time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+				continue
+			}
+			writeK8sError(w, "update human", err)
+			return
+		}
+
+		httputil.WriteJSON(w, http.StatusOK, humanToResponse(&human))
+		return
+	}
+}
+
+// errDanglingReference marks validation errors where a referenced Team or
+// Worker does not exist (a client error, mapped to 400 by the caller).
+// Any other error from validateHumanReferences is a backend lookup
+// failure (mapped to a server error).
+var errDanglingReference = errors.New("dangling reference")
+
+// validateHumanReferences rejects permission grants that point at missing
+// Teams or Workers: a dangling reference silently widens nothing but leaves
+// the human unable to reach a resource they believe they can. Missing
+// references are returned wrapped in errDanglingReference; backend lookup
+// failures (List/Get errors other than NotFound) are returned unwrapped so
+// the caller can surface them as a server error instead of a 400.
+func (h *ResourceHandler) validateHumanReferences(ctx context.Context, teams *[]string, workers *[]string) error {
+	if teams != nil {
+		var teamList v1beta1.TeamList
+		if err := h.client.List(ctx, &teamList, client.InNamespace(h.namespace)); err != nil {
+			return fmt.Errorf("list teams: %w", err)
+		}
+		existing := make(map[string]struct{}, len(teamList.Items))
+		for i := range teamList.Items {
+			existing[teamList.Items[i].Name] = struct{}{}
+		}
+		var missing []string
+		for _, t := range *teams {
+			if t == "" {
+				continue
+			}
+			if _, ok := existing[t]; !ok {
+				missing = append(missing, t)
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("%w: accessibleTeams references missing teams: %s", errDanglingReference, strings.Join(missing, ", "))
+		}
+	}
+	if workers != nil {
+		var missing []string
+		for _, wn := range *workers {
+			if wn == "" {
+				continue
+			}
+			var worker v1beta1.Worker
+			if err := h.client.Get(ctx, client.ObjectKey{Name: wn, Namespace: h.namespace}, &worker); err != nil {
+				if apierrors.IsNotFound(err) {
+					missing = append(missing, wn)
+					continue
+				}
+				return fmt.Errorf("get worker %s: %w", wn, err)
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("%w: accessibleWorkers references missing workers: %s", errDanglingReference, strings.Join(missing, ", "))
+		}
+	}
+	return nil
 }
 
 func (h *ResourceHandler) ListHumans(w http.ResponseWriter, r *http.Request) {

--- a/agentteams-controller/internal/server/resource_handler_human_update_test.go
+++ b/agentteams-controller/internal/server/resource_handler_human_update_test.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func newHumanUpdateRig(t *testing.T) *ResourceHandler {
+	t.Helper()
+	scheme := newServerTestScheme(t)
+	team := &v1beta1.Team{ObjectMeta: metav1.ObjectMeta{Name: "market-team", Namespace: "default"}}
+	worker := &v1beta1.Worker{ObjectMeta: metav1.ObjectMeta{Name: "market-dev", Namespace: "default"}}
+	human := &v1beta1.Human{
+		ObjectMeta: metav1.ObjectMeta{Name: "maizong", Namespace: "default"},
+		Spec: v1beta1.HumanSpec{
+			DisplayName:     "Mai",
+			Email:           "maizong@example.com",
+			PermissionLevel: 2,
+			AccessibleTeams: []string{"market-team"},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(team, worker, human).Build()
+	return NewResourceHandler(k8sClient, "default", nil, "")
+}
+
+func putHuman(t *testing.T, handler *ResourceHandler, name, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/humans/"+name, bytes.NewReader([]byte(body)))
+	req.SetPathValue("name", name)
+	rec := httptest.NewRecorder()
+	handler.UpdateHuman(rec, req)
+	return rec
+}
+
+func TestUpdateHuman_LevelAndTeamsApplied(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "maizong", `{"permissionLevel":1,"accessibleTeams":["market-team"],"displayName":"Mai Zong"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp HumanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.PermissionLevel != 1 {
+		t.Errorf("level = %d, want 1", resp.PermissionLevel)
+	}
+	if resp.DisplayName != "Mai Zong" {
+		t.Errorf("displayName = %q", resp.DisplayName)
+	}
+	// Untouched field preserved.
+	if resp.Email != "maizong@example.com" {
+		t.Errorf("email changed: %q", resp.Email)
+	}
+}
+
+func TestUpdateHuman_PartialMergePreservesOthers(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "maizong", `{"note":"onboarding done"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp HumanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.PermissionLevel != 2 || len(resp.AccessibleTeams) != 1 {
+		t.Errorf("partial merge clobbered fields: level=%d teams=%v", resp.PermissionLevel, resp.AccessibleTeams)
+	}
+	if resp.Note != "onboarding done" {
+		t.Errorf("note = %q", resp.Note)
+	}
+}
+
+func TestUpdateHuman_ClearsListWithEmptyArray(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "maizong", `{"accessibleTeams":[]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp HumanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.AccessibleTeams != nil {
+		t.Errorf("expected cleared list, got %v", resp.AccessibleTeams)
+	}
+}
+
+func TestUpdateHuman_InvalidLevelRejected(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	for _, level := range []string{"0", "4", "-1"} {
+		rec := putHuman(t, handler, "maizong", `{"permissionLevel":`+level+`}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("level %s: expected 400, got %d: %s", level, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestUpdateHuman_MissingTeamRejected(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "maizong", `{"accessibleTeams":["ghost-team"]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("ghost-team")) {
+		t.Errorf("error should name the missing team: %s", rec.Body.String())
+	}
+}
+
+func TestUpdateHuman_MissingWorkerRejected(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "maizong", `{"accessibleWorkers":["ghost-dev"]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("ghost-dev")) {
+		t.Errorf("error should name the missing worker: %s", rec.Body.String())
+	}
+}
+
+func TestUpdateHuman_ExistingWorkerAllowed(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "maizong", `{"accessibleWorkers":["market-dev"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUpdateHuman_NotFound(t *testing.T) {
+	handler := newHumanUpdateRig(t)
+	rec := putHuman(t, handler, "ghost", `{}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A backend failure while listing Teams is a server error, not a 400 on the
+// request — the request itself may be perfectly valid.
+func TestUpdateHuman_TeamListFailureIsServerError(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	human := &v1beta1.Human{ObjectMeta: metav1.ObjectMeta{Name: "maizong", Namespace: "default"}}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(human).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				return errors.New("k8s api timeout")
+			},
+		}).
+		Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+	rec := putHuman(t, handler, "maizong", `{"accessibleTeams":["market-team"]}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for backend list failure, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("validate human references")) {
+		t.Errorf("server error should carry the validation op, got: %s", rec.Body.String())
+	}
+}
+
+// Same for a Worker Get that fails with a non-NotFound backend error.
+func TestUpdateHuman_WorkerGetFailureIsServerError(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	human := &v1beta1.Human{ObjectMeta: metav1.ObjectMeta{Name: "maizong", Namespace: "default"}}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(human).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1beta1.Worker); ok {
+					return errors.New("k8s api timeout")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+	rec := putHuman(t, handler, "maizong", `{"accessibleWorkers":["market-dev"]}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for backend get failure, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("validate human references")) {
+		t.Errorf("server error should carry the validation op, got: %s", rec.Body.String())
+	}
+}

--- a/agentteams-controller/internal/server/types.go
+++ b/agentteams-controller/internal/server/types.go
@@ -153,6 +153,19 @@ type CreateHumanRequest struct {
 	Note              string   `json:"note,omitempty"`
 }
 
+// UpdateHumanRequest is the merge-patch body of PUT /api/v1/humans/{name}.
+// Pointer fields: absent = unchanged, present = replace (an empty non-nil
+// slice clears the list). Matrix identity (name / username) is not
+// updatable — changing it re-provisions the account.
+type UpdateHumanRequest struct {
+	DisplayName       *string   `json:"displayName,omitempty"`
+	Email             *string   `json:"email,omitempty"`
+	PermissionLevel   *int      `json:"permissionLevel,omitempty"`
+	AccessibleTeams   *[]string `json:"accessibleTeams,omitempty"`
+	AccessibleWorkers *[]string `json:"accessibleWorkers,omitempty"`
+	Note              *string   `json:"note,omitempty"`
+}
+
 type HumanResponse struct {
 	Name              string   `json:"name"`
 	Phase             string   `json:"phase"`

--- a/docs/design/humans-update-api.md
+++ b/docs/design/humans-update-api.md
@@ -1,0 +1,91 @@
+# Human Update API
+
+Status: implemented
+API: `PUT /api/v1/humans/{name}`
+
+## Problem
+
+Human lifecycle had create / get / list / delete but no update. Changing a
+human's permission level, team scope, or worker scope required deleting and
+re-creating the Human CR — which re-provisions the Matrix account and hands
+out a fresh one-time password, destroying the identity the user already
+logged in with. There was also no way to narrow or widen an existing grant
+as teams form and dissolve.
+
+## Design
+
+`PUT /api/v1/humans/{name}` — a merge-patch over the mutable part of
+`spec`:
+
+- **Pointer semantics** (the existing `containerManaged` / `state` pattern):
+  absent field = unchanged; present field = replace; an explicitly empty
+  list clears the list.
+- **Mutable fields:** `displayName`, `email`, `permissionLevel`,
+  `accessibleTeams`, `accessibleWorkers`, `note`.
+- **Immutable through this endpoint:** `name` and the Matrix identity
+  (username / matrixUserID). Re-provisioning the account is a deliberate
+  destroy-and-recreate operation, not an edit.
+- **Validation, applied before the K8s write:**
+  - `permissionLevel` must be 1, 2, or 3 → otherwise `400`.
+  - `accessibleTeams` must reference existing Team CRs and
+    `accessibleWorkers` existing Worker CRs → otherwise `400` naming the
+    missing references. A dangling grant silently widens nothing but
+    leaves the human unable to reach a resource they believe they can;
+    rejecting it at write time keeps the permission model honest.
+- **Authorization:** the route is `ActionUpdate` on the `human` kind. The
+  existing matrix already allows that only for admin/manager; team leaders,
+  team-scoped humans, and worker accounts fall through to the default deny.
+  No authorizer change is required.
+- **Reconcile integration:** the write updates the Human CR; the existing
+  human reconciler (identity / infra / rooms phases) re-syncs Matrix
+  invitations, room membership, and `groupAllowFrom` on its normal cycle.
+  No new reconcile path.
+- **Out of scope — room power levels:** this endpoint does not grant or
+  revoke Matrix room administration. A `permissionLevel` change takes
+  effect on API authorization immediately, but it does not by itself
+  change the power level the human already holds in existing rooms;
+  reconciling room power levels for human members is a separate concern
+  that this endpoint and its reconciler integration do not handle.
+
+## Contract
+
+`PUT /api/v1/humans/{name}` →
+
+| Result | Code |
+|--------|------|
+| updated | `200` + full human representation |
+| human not found | `404` |
+| invalid JSON / bad level / dangling reference | `400` |
+| reference validation backend failure (K8s error) | `500` |
+| K8s conflict after retries | `409` |
+
+Request body (all fields optional):
+
+```json
+{
+  "displayName": "Mai Zong",
+  "email": "maizong@example.com",
+  "permissionLevel": 2,
+  "accessibleTeams": ["market-team"],
+  "accessibleWorkers": [],
+  "note": "Marketing lead"
+}
+```
+
+## Out of scope
+
+- Matrix identity changes (account re-provisioning).
+- Self-service updates by the human themselves (an L2 human updating their
+  own grants would be a privilege escalation path; admin-only is the safe
+  default).
+- Bulk updates.
+
+## Tests
+
+- `internal/server/resource_handler_human_update_test.go` — level + teams
+  update applied with untouched fields preserved; partial merge preserves
+  the rest; explicit empty list clears; invalid levels (0/4/-1) → 400;
+  missing team → 400 named; missing worker → 400 named; existing worker →
+  200; unknown human → 404.
+- `internal/auth/authorizer_test.go` — `TestAuthorizer_HumanUpdateAdminOnly`:
+  admin/manager allowed; team leader, L2 human, and worker denied.

--- a/docs/usage/resource-management.md
+++ b/docs/usage/resource-management.md
@@ -494,6 +494,17 @@ Human permissions are enforced through two mechanisms:
 | L2 | Added to specified Teams' Leaders + Workers + specified standalone Workers | Specified Team Rooms + Worker Rooms |
 | L3 | Added to specified Workers | Specified Worker Rooms |
 
+### Human Updates (API)
+
+`PUT /api/v1/humans/{name}` updates an existing human's permission profile. It is a merge-patch: only fields present in the body change; an absent field is kept, and an explicitly empty list clears it.
+
+- **Updatable:** `displayName`, `email`, `permissionLevel` (1/2/3), `accessibleTeams`, `accessibleWorkers`, `note`.
+- **Not updatable:** `name` and the Matrix identity (re-provisioning the account is a separate operation).
+- **Validation:** `permissionLevel` outside 1–3 → `400`; `accessibleTeams` / `accessibleWorkers` referencing missing Teams/Workers → `400` naming the references.
+- **Authorization:** admin / manager only. Team leaders, team-scoped humans, and worker accounts are denied — permission grants are an admin operation.
+
+The update is applied to the Human CR; the existing human reconcile then re-syncs Matrix invitations, room memberships, and `groupAllowFrom` to match the new scope. This endpoint does not change Matrix room power levels: a `permissionLevel` change affects API authorization immediately, but room administration privileges in existing rooms are not altered by the update.
+
 ### Human Creation Flow
 
 1. Register a Matrix account (random password auto-generated)

--- a/docs/zh-cn/usage/resource-management.md
+++ b/docs/zh-cn/usage/resource-management.md
@@ -493,6 +493,17 @@ Human 的权限通过两个机制实现：
 | L2 | 添加到指定 Team 的 Leader + Worker + 指定独立 Worker | 指定 Team Room + Worker Room |
 | L3 | 添加到指定 Worker | 指定 Worker Room |
 
+### Human 更新（API）
+
+`PUT /api/v1/humans/{name}` 更新既有 human 的权限配置。合并补丁语义：body 里出现的字段才变，未出现保持原值，显式空数组清空列表。
+
+- **可更新：** `displayName`、`email`、`permissionLevel`（1/2/3）、`accessibleTeams`、`accessibleWorkers`、`note`。
+- **不可更新：** `name` 与 Matrix 身份（账号重新开通是独立操作）。
+- **校验：** `permissionLevel` 超出 1–3 → `400`；`accessibleTeams` / `accessibleWorkers` 引用不存在的 Team/Worker → `400` 并点名。
+- **鉴权：** 仅 admin / manager。团队 Leader、团队范围人类用户、worker 账号一律拒绝——授权是管理员操作。
+
+更新写入 Human CR，既有的 human reconcile 自动把 Matrix 邀请、房间成员、`groupAllowFrom` 重新同步到新范围。注意：本端点不修改 Matrix 房间 power level——`permissionLevel` 变更立即对 API 鉴权生效，但既有房间的管理权限不因本次更新而改变（房间 power level 的对账是独立的变更，不属于本端点）。
+
 ### Human 创建流程
 
 1. 注册 Matrix 账号（自动生成随机密码）


### PR DESCRIPTION
# Human update endpoint (PUT /api/v1/humans/{name})

## Summary

Human lifecycle had create / get / list / delete but no update. Changing a human's permission level or team/worker scope meant deleting and re-creating the Human CR — which re-provisions the Matrix account and issues a fresh one-time password, destroying the identity the user already logged in with.

This PR adds `PUT /api/v1/humans/{name}`:

- **Merge-patch semantics** (pointer fields, the pattern already used for `containerManaged`/`state`): absent = unchanged, present = replace, explicit empty list = clear.
- **Mutable:** `displayName`, `email`, `permissionLevel`, `accessibleTeams`, `accessibleWorkers`, `note`. **Not mutable:** `name` and the Matrix identity — re-provisioning the account is a deliberate destroy-and-recreate, not an edit.
- **Validation before the write:** `permissionLevel` outside 1–3 → `400`; `accessibleTeams`/`accessibleWorkers` referencing missing Team/Worker resources → `400` naming the references. A dangling grant would silently widen nothing but leave the human unable to reach a resource they believe they can; rejecting at write time keeps the permission model honest.
- **Authorization:** `ActionUpdate` on the `human` kind already passes only for admin/manager in the existing matrix; team leaders, team-scoped humans, and worker accounts hit the default deny. Self-service updates by the human themselves are deliberately out of scope (updating one's own grants is a privilege-escalation path). No authorizer change required.
- **Reconcile integration:** the write updates the Human CR; the existing human reconciler re-syncs Matrix invitations, room membership, and `groupAllowFrom` on its normal cycle. No new reconcile path.

Note on related work: PR #796 proposes a similar update endpoint. This PR takes a different, validation-first design (dangling-reference rejection, pointer merge semantics, documented immutables) and is self-contained — either may merge, but this one is the version we can maintain.

## What's included

- `internal/server/http.go` — `PUT /api/v1/humans/{name}` route.
- `internal/server/types.go` — `UpdateHumanRequest` (pointer fields).
- `internal/server/resource_handler.go` — `UpdateHuman` (conflict-retry loop, same as the other updates) + `validateHumanReferences`.
- `docs/design/humans-update-api.md` — design contract.
- `docs/usage/resource-management.md` (+ zh-cn) — Human updates section.

## Data boundary

- No CRD or schema change; no new resources; no new reconcile paths — the existing human reconciler consumes the updated spec.
- The endpoint never touches Matrix directly; identity fields are not writable, so a human's account and one-time password are unaffected by an update.
- Dangling references are rejected, not stored: the permission model has no "points at nothing" state.
- Errors: `404` unknown human, `400` invalid JSON / level / dangling reference, `409` K8s conflict after retries — same mapping as the existing CRUD handlers.

## Tests

- `internal/server/resource_handler_human_update_test.go` (new, 8 cases): level + teams update applied with untouched fields preserved; partial merge preserves the rest; explicit empty list clears; levels 0/4/-1 → 400; missing team → 400 named; missing worker → 400 named; existing worker → 200; unknown human → 404.
- `internal/auth/authorizer_test.go` — `TestAuthorizer_HumanUpdateAdminOnly`: admin/manager allowed; team leader, L2 human, worker denied.
- `go test ./internal/server/ ./internal/auth/` green; full `go test ./...`: 19 packages ok, the only failure is a pre-existing environment issue in `internal/executor` (unzip binary absent in the test container) untouched by this diff. `gofmt`/`go vet` clean.

## Related

- PR #796 (alternative design for the same gap).
- Design: `docs/design/humans-update-api.md`.
- Related design: #1217 (L2 team-scoped workspace access) · #1220 (capability model — PR-A capability foundation builds on this API).

---

# Human 更新端点（PUT /api/v1/humans/{name}）

## 摘要

Human 生命周期只有创建/查询/列表/删除，没有更新。改权限级别或团队/Worker 范围只能删了重建——这会重新开通 Matrix 账号并发放新的一次性密码，把用户已登录的身份毁掉。

本 PR 新增 `PUT /api/v1/humans/{name}`：

- **合并补丁语义**（pointer 字段，沿用 `containerManaged`/`state` 的既有模式）：未出现 = 不变，出现 = 替换，显式空数组 = 清空。
- **可更新：** `displayName`、`email`、`permissionLevel`、`accessibleTeams`、`accessibleWorkers`、`note`。**不可更新：** `name` 与 Matrix 身份——账号重新开通是有意的删建操作，不是编辑。
- **写前校验：** `permissionLevel` 超出 1–3 → `400`；`accessibleTeams`/`accessibleWorkers` 引用不存在的 Team/Worker → `400` 点名。悬空授权不会真的扩大任何权限，但会让人类用户够不到自己以为能访问的资源；写时拒绝让权限模型保持诚实。
- **鉴权：** `human` 的 `ActionUpdate` 在既有矩阵里本来就只放行 admin/manager；团队 Leader、团队范围人类用户、worker 账号走 default deny。人类用户自改自己的授权刻意排除在外（那是提权路径）。零 authorizer 改动。
- **reconcile 集成：** 写操作只更新 Human CR，既有的 human reconciler 在正常周期内重新同步 Matrix 邀请、房间成员、`groupAllowFrom`。无新 reconcile 路径。

关于相关 PR：#796 提出了类似的更新端点。本 PR 采用校验优先的不同设计（悬空引用拒绝、pointer 合并语义、明确不可变字段），自包含——两者可任选合并，本 PR 是我们能长期维护的版本。

## 包含内容

- `internal/server/http.go` — `PUT /api/v1/humans/{name}` 路由。
- `internal/server/types.go` — `UpdateHumanRequest`（pointer 字段）。
- `internal/server/resource_handler.go` — `UpdateHuman`（conflict-retry 循环，与其他更新一致）+ `validateHumanReferences`。
- `docs/design/humans-update-api.md` — 设计契约。
- `docs/usage/resource-management.md`（+ zh-cn）— Human 更新节。

## 数据边界

- 无 CRD/schema 变更、无新资源、无新 reconcile 路径——既有 human reconciler 直接消费更新后的 spec。
- 端点不直接碰 Matrix；身份字段不可写，更新不影响账号与一次性密码。
- 悬空引用被拒绝而非存储：权限模型没有「指向空」的状态。
- 错误映射与既有 CRUD 一致：`404` 未找到、`400` 非法 JSON/级别/悬空引用、`409` 重试耗尽。

## 测试

- `internal/server/resource_handler_human_update_test.go`（新，8 用例）：level+teams 更新生效且未触碰字段保留；部分合并保留其余字段；显式空数组清空；level 0/4/-1 → 400；缺失 team → 400 点名；缺失 worker → 400 点名；存在 worker → 200；未找到 human → 404。
- `internal/auth/authorizer_test.go` — `TestAuthorizer_HumanUpdateAdminOnly`：admin/manager 放行；团队 Leader、L2 人类、worker 拒绝。
- `go test ./internal/server/ ./internal/auth/` 全绿；全量 `go test ./...`：19 包 ok，唯一失败为 `internal/executor` 预存环境问题（测试容器缺 unzip），与本 diff 无关。`gofmt`/`go vet` 干净。

## 相关

- PR #796（同一缺口的替代设计）。
- 设计文档：`docs/design/humans-update-api.md`。
