### PR TITLE
feat(controller): add read-only skill catalog endpoint for workbench

### DIFF
--- a/agentteams-controller/internal/app/app.go
+++ b/agentteams-controller/internal/app/app.go
@@ -653,6 +653,7 @@ func (a *App) initHTTPServer(_ context.Context) error {
 		Provisioner:     a.provisioner,
 
 		DefaultWorkerRuntime: a.cfg.DefaultWorkerRuntime,
+		WorkerAgentDir:       a.cfg.WorkerAgentDir(),
 	})
 	return nil
 }

--- a/agentteams-controller/internal/auth/authorizer.go
+++ b/agentteams-controller/internal/auth/authorizer.go
@@ -143,6 +143,15 @@ func (a *Authorizer) authorizeHuman(caller *CallerIdentity, req AuthzRequest) er
 		}
 		return deny(caller, req)
 
+	case "skills":
+		// Read-only skill catalog (name/description metadata); no PII,
+		// scope-independent. Only the list action is granted — any other
+		// action on this resource is denied, not defaulted.
+		if req.Action == ActionList {
+			return nil
+		}
+		return deny(caller, req)
+
 	default:
 		return deny(caller, req)
 	}
@@ -168,6 +177,15 @@ func (a *Authorizer) authorizeTeamLeader(caller *CallerIdentity, req AuthzReques
 		// calling identity, and these routes never embed a target ResourceName
 		// (the handler uses caller.Username), so no requireSelf check is needed.
 		if req.Action == ActionSTS || req.Action == ActionRefreshMatrixToken {
+			return nil
+		}
+		return deny(caller, req)
+
+	case "skills":
+		// Read-only skill catalog (name/description metadata); no PII,
+		// scope-independent. Only the list action is granted — any other
+		// action on this resource is denied, not defaulted.
+		if req.Action == ActionList {
 			return nil
 		}
 		return deny(caller, req)

--- a/agentteams-controller/internal/auth/authorizer_test.go
+++ b/agentteams-controller/internal/auth/authorizer_test.go
@@ -102,6 +102,27 @@ func TestAuthorizer_HumanUpdateAdminOnly(t *testing.T) {
 	}
 }
 
+// TestAuthorizer_SkillsListOnly pins the skill catalog boundary: the skills
+// resource is read-only and grants exactly ActionList — any other action
+// (including ActionGet) is denied rather than defaulted.
+func TestAuthorizer_SkillsListOnly(t *testing.T) {
+	az := NewAuthorizer()
+	roles := []*CallerIdentity{
+		{Role: RoleHuman, Username: "maizong", Teams: []string{"market-team"}},
+		{Role: RoleTeamLeader, Username: "market-lead", Team: "market-team"},
+	}
+	for _, caller := range roles {
+		if err := az.Authorize(caller, AuthzRequest{Action: ActionList, ResourceKind: "skills"}); err != nil {
+			t.Errorf("%s: ActionList on skills should be allowed, got: %v", caller.Role, err)
+		}
+		for _, action := range []Action{ActionGet, ActionCreate, ActionUpdate, ActionDelete} {
+			if err := az.Authorize(caller, AuthzRequest{Action: action, ResourceKind: "skills"}); err == nil {
+				t.Errorf("%s: %s on skills must be denied, got nil error", caller.Role, action)
+			}
+		}
+	}
+}
+
 func TestAuthorizer_TeamLeaderOwnTeam(t *testing.T) {
 	az := NewAuthorizer()
 	caller := &CallerIdentity{Role: RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"}

--- a/agentteams-controller/internal/oss/client.go
+++ b/agentteams-controller/internal/oss/client.go
@@ -21,7 +21,22 @@ var ErrPreconditionFailed = errors.New("oss: precondition failed (etag mismatch)
 
 // StorageClient abstracts object storage operations.
 // Implementations: MinIOClient (mc CLI), future S3Client (aws-sdk-go).
+// ObjectInfo is a listing entry with the last-updated timestamp when the
+// backend can provide it.
+type ObjectInfo struct {
+	Name string
+	// UpdatedAt is RFC3339 UTC, or "" when the backend does not expose
+	// (or the parser cannot decode) a timestamp.
+	UpdatedAt string
+}
+
 type StorageClient interface {
+	// ListObjectsDetailed is like ListObjects but also reports each entry's
+	// last-updated timestamp when the backend exposes one (mc ls lines carry
+	// a date). Unparseable dates degrade to UpdatedAt == "" — a listing must
+	// never fail because of timestamp parsing.
+	ListObjectsDetailed(ctx context.Context, prefix string) ([]ObjectInfo, error)
+
 	// PutObject writes data to the given key path.
 	// Key is relative to the configured storage prefix.
 	PutObject(ctx context.Context, key string, data []byte) error

--- a/agentteams-controller/internal/oss/minio.go
+++ b/agentteams-controller/internal/oss/minio.go
@@ -316,6 +316,18 @@ func (c *MinIOClient) DeletePrefix(ctx context.Context, prefix string) error {
 }
 
 func (c *MinIOClient) ListObjects(ctx context.Context, prefix string) ([]string, error) {
+	infos, err := c.ListObjectsDetailed(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(infos))
+	for _, info := range infos {
+		names = append(names, info.Name)
+	}
+	return names, nil
+}
+
+func (c *MinIOClient) ListObjectsDetailed(ctx context.Context, prefix string) ([]ObjectInfo, error) {
 	if err := c.ensureAlias(ctx); err != nil {
 		return nil, err
 	}
@@ -324,7 +336,7 @@ func (c *MinIOClient) ListObjects(ctx context.Context, prefix string) ([]string,
 		return nil, err
 	}
 
-	var names []string
+	var infos []ObjectInfo
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -332,11 +344,23 @@ func (c *MinIOClient) ListObjects(ctx context.Context, prefix string) ([]string,
 		}
 		// mc ls output format: "[date] [size] filename"
 		parts := strings.Fields(line)
-		if len(parts) > 0 {
-			names = append(names, parts[len(parts)-1])
+		if len(parts) == 0 {
+			continue
 		}
+		info := ObjectInfo{Name: parts[len(parts)-1]}
+		// mc ls prints the date in the mc process's local zone; the
+		// reference deployment runs the controller in UTC. A parse failure
+		// (format drift between mc versions) degrades to an empty timestamp
+		// rather than failing the listing.
+		if len(parts) >= 3 {
+			raw := strings.TrimPrefix(parts[0], "[") + " " + parts[1]
+			if t, err := time.Parse("2006-01-02 15:04:05", raw); err == nil {
+				info.UpdatedAt = t.UTC().Format(time.RFC3339)
+			}
+		}
+		infos = append(infos, info)
 	}
-	return names, nil
+	return infos, nil
 }
 
 // EnsureBucket creates the configured bucket if it does not already exist.

--- a/agentteams-controller/internal/oss/ossfake/memory.go
+++ b/agentteams-controller/internal/oss/ossfake/memory.go
@@ -90,6 +90,14 @@ func (m *Memory) Stat(_ context.Context, key string) error {
 	return nil
 }
 
+// LastWriteTime returns the fake's global write clock (the mtime that
+// ListObjectsDetailed reports for every entry).
+func (m *Memory) LastWriteTime() time.Time {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.modTime
+}
+
 // StatMeta returns a monotonic mtime for the object. Writes advance the clock,
 // so a test can verify the optimistic-lock conflict path by writing after a
 // read. The ETag is the content MD5 (mirroring MinIO single-part semantics),
@@ -158,16 +166,36 @@ func (m *Memory) Mirror(_ context.Context, src, dst string, _ oss.MirrorOptions)
 
 // ListObjects returns all keys whose names start with prefix, sorted.
 func (m *Memory) ListObjects(_ context.Context, prefix string) ([]string, error) {
+	infos, err := m.ListObjectsDetailed(context.Background(), prefix)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, info.Name)
+	}
+	return out, nil
+}
+
+// ListObjectsDetailed reports the fake's single global write clock as every
+// entry's UpdatedAt (the fake has no per-object mtime; writes advance the
+// clock, so the value reflects the most recent write).
+func (m *Memory) ListObjectsDetailed(_ context.Context, prefix string) ([]oss.ObjectInfo, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	out := make([]string, 0)
+	keys := make([]string, 0)
 	for key := range m.objects {
 		if strings.HasPrefix(key, prefix) {
-			out = append(out, key)
+			keys = append(keys, key)
 		}
 	}
-	sort.Strings(out)
-	return out, nil
+	sort.Strings(keys)
+	updatedAt := m.modTime.UTC().Format(time.RFC3339)
+	infos := make([]oss.ObjectInfo, 0, len(keys))
+	for _, key := range keys {
+		infos = append(infos, oss.ObjectInfo{Name: key, UpdatedAt: updatedAt})
+	}
+	return infos, nil
 }
 
 // DeletePrefix removes every object whose key starts with prefix.

--- a/agentteams-controller/internal/server/http.go
+++ b/agentteams-controller/internal/server/http.go
@@ -35,6 +35,7 @@ type ServerDeps struct {
 	Provisioner     *service.Provisioner // for Matrix token refresh
 
 	DefaultWorkerRuntime string // install-time default for Worker create requests
+	WorkerAgentDir       string // source of builtin agent templates (skill catalog)
 }
 
 // HTTPServer serves the unified controller REST API.
@@ -136,6 +137,10 @@ func NewHTTPServer(addr string, deps ServerDeps) *HTTPServer {
 	ah := NewApprovalHandler(deps.Client, deps.Namespace, deps.KubeMode, deps.ContainerPrefix)
 	mux.Handle("GET /api/v1/workers/{name}/approval", mw.RequireAuthz(authpkg.ActionGet, "worker", nameFn)(http.HandlerFunc(ah.getWorkerApproval)))
 	mux.Handle("PUT /api/v1/workers/{name}/approval", mw.RequireAuthz(authpkg.ActionWorkerApproval, "worker", nameFn)(http.HandlerFunc(ah.updateWorkerApproval)))
+
+	// --- Skill catalog (read-only: builtin skills per runtime + shared skills under agents/global/skills/) ---
+	skh := NewSkillsHandler(deps.WorkerAgentDir, deps.OSS)
+	mux.Handle("GET /api/v1/skills", mw.RequireAuthz(authpkg.ActionList, "skills", nil)(http.HandlerFunc(skh.ListSkills)))
 
 	// W-PR-2: human intervention + lifecycle (write endpoints). All writes go
 	// through RequireAuthz ActionUpdate + "project" so the authorizer's

--- a/agentteams-controller/internal/server/project_handler_test.go
+++ b/agentteams-controller/internal/server/project_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 
@@ -51,12 +52,27 @@ func (m *mcLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, err
 	if m.failList {
 		return nil, errors.New("oss list failed")
 	}
+	infos, err := m.ListObjectsDetailed(context.Background(), prefix)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, info.Name)
+	}
+	return out, nil
+}
+
+// ListObjectsDetailed groups the fake's flat keys into direct-child directory
+// names (the mc ls directory view) and stamps each with the fake's global
+// write clock.
+func (m *mcLikeOSS) ListObjectsDetailed(_ context.Context, prefix string) ([]oss.ObjectInfo, error) {
 	keys, err := m.Memory.ListObjects(context.Background(), prefix)
 	if err != nil {
 		return nil, err
 	}
 	seen := map[string]bool{}
-	out := make([]string, 0)
+	out := make([]oss.ObjectInfo, 0)
 	for _, k := range keys {
 		rest := strings.TrimPrefix(k, prefix)
 		parts := strings.SplitN(rest, "/", 2)
@@ -66,10 +82,10 @@ func (m *mcLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, err
 		dir := parts[0] + "/"
 		if !seen[dir] {
 			seen[dir] = true
-			out = append(out, dir)
+			out = append(out, oss.ObjectInfo{Name: dir, UpdatedAt: m.Memory.LastWriteTime().UTC().Format(time.RFC3339)})
 		}
 	}
-	sort.Strings(out)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
 
@@ -3632,6 +3648,10 @@ func (c *conflictInjectingOSS) ListObjects(ctx context.Context, prefix string) (
 	return c.mcLike.ListObjects(ctx, prefix)
 }
 
+func (c *conflictInjectingOSS) ListObjectsDetailed(ctx context.Context, prefix string) ([]oss.ObjectInfo, error) {
+	return c.mcLike.ListObjectsDetailed(ctx, prefix)
+}
+
 func (c *conflictInjectingOSS) GetObject(ctx context.Context, key string) ([]byte, error) {
 	data, err := c.mcLike.GetObject(ctx, key)
 	c.getCalls++
@@ -3695,6 +3715,18 @@ type bareLikeOSS struct {
 }
 
 func (m *bareLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, error) {
+	infos, err := m.ListObjectsDetailed(context.Background(), prefix)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, info.Name)
+	}
+	return out, nil
+}
+
+func (m *bareLikeOSS) ListObjectsDetailed(_ context.Context, prefix string) ([]oss.ObjectInfo, error) {
 	keys, err := m.Memory.ListObjects(context.Background(), prefix)
 	if err != nil {
 		return nil, err
@@ -3702,7 +3734,7 @@ func (m *bareLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, e
 	// mc ls semantics: direct children only — directory children keep the
 	// trailing slash ("p1/"), file children stay bare ("t1.json").
 	seen := map[string]bool{}
-	out := make([]string, 0)
+	out := make([]oss.ObjectInfo, 0)
 	for _, k := range keys {
 		rest := strings.TrimPrefix(k, prefix)
 		if rest == "" {
@@ -3715,10 +3747,10 @@ func (m *bareLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, e
 		}
 		if !seen[child] {
 			seen[child] = true
-			out = append(out, child)
+			out = append(out, oss.ObjectInfo{Name: child, UpdatedAt: m.Memory.LastWriteTime().UTC().Format(time.RFC3339)})
 		}
 	}
-	sort.Strings(out)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
 

--- a/agentteams-controller/internal/server/project_history_test.go
+++ b/agentteams-controller/internal/server/project_history_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
 	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
@@ -26,12 +27,24 @@ type lsLikeOSS struct {
 }
 
 func (m *lsLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, error) {
+	infos, err := m.ListObjectsDetailed(context.Background(), prefix)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, info.Name)
+	}
+	return out, nil
+}
+
+func (m *lsLikeOSS) ListObjectsDetailed(_ context.Context, prefix string) ([]oss.ObjectInfo, error) {
 	keys, err := m.Memory.ListObjects(context.Background(), prefix)
 	if err != nil {
 		return nil, err
 	}
 	seen := map[string]bool{}
-	out := make([]string, 0)
+	out := make([]oss.ObjectInfo, 0)
 	for _, k := range keys {
 		rest := strings.TrimPrefix(k, prefix)
 		parts := strings.SplitN(rest, "/", 2)
@@ -44,10 +57,10 @@ func (m *lsLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, err
 		}
 		if !seen[child] {
 			seen[child] = true
-			out = append(out, child)
+			out = append(out, oss.ObjectInfo{Name: child, UpdatedAt: m.Memory.LastWriteTime().UTC().Format(time.RFC3339)})
 		}
 	}
-	sort.Strings(out)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
 }
 

--- a/agentteams-controller/internal/server/skills_handler.go
+++ b/agentteams-controller/internal/server/skills_handler.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/httputil"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
+)
+
+// globalSkillsPrefix is the deployment-wide skill staging area maintained by
+// the dashboard's skill-upload flow. Listing it read-only gives the catalog
+// its "shared" half — the set of skills available for distribution across
+// the deployment.
+//
+// Retention semantics: no worker entrypoint consumes this prefix
+// automatically. A shared skill reaches a worker only through per-worker
+// distribution (dashboard Worker dialog, or L1/L2 PUT /workers skills),
+// which also records the assignment in spec.skills. Deleting
+// agents/global/skills/{name}/ removes the skill from the catalog (and the
+// dashboard's global area); already-distributed per-worker copies
+// (agents/<worker>/skills/{name}/) and existing spec.skills assignments are
+// NOT touched — there is no cascade.
+const globalSkillsPrefix = "agents/global/skills/"
+
+// SkillInfo is one entry of the read-only skill catalog. It carries
+// identity/availability only — never skill content, credentials, or
+// registry connection details.
+type SkillInfo struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Source      string   `json:"source"` // "builtin" | "shared"
+	Agents      []string `json:"agents,omitempty"`   // builtin only: template dirs providing the skill
+	Runtimes    []string `json:"runtimes,omitempty"` // runtimes for which the skill is available
+}
+
+// SkillListResponse is the payload of GET /api/v1/skills.
+type SkillListResponse struct {
+	Skills []SkillInfo `json:"skills"`
+	Total  int         `json:"total"`
+}
+
+// SkillsHandler serves the read-only skill catalog: built-in skills from the
+// controller's agent template directories (availability per runtime derived
+// from service.BuiltinAgentDir, the same function the Deployer uses to seed
+// workers) plus the deployment-wide shared skills staged under
+// agents/global/skills/. It never reads skill content beyond the SKILL.md
+// frontmatter (name/description) of builtin skills.
+type SkillsHandler struct {
+	workerAgentDir string
+	oss            oss.StorageClient
+}
+
+func NewSkillsHandler(workerAgentDir string, o oss.StorageClient) *SkillsHandler {
+	return &SkillsHandler{workerAgentDir: workerAgentDir, oss: o}
+}
+
+// ListSkills handles GET /api/v1/skills.
+func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
+	skills := map[string]*SkillInfo{}
+
+	for _, tmpl := range h.builtinTemplates() {
+		skillRoot := filepath.Join(tmpl.dir, "skills")
+		entries, err := os.ReadDir(skillRoot)
+		if err != nil {
+			continue // missing template dir for this deployment
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name, description := parseSkillFrontmatter(filepath.Join(skillRoot, entry.Name(), "SKILL.md"))
+			if name == "" {
+				name = entry.Name()
+			}
+			if info, ok := skills[name]; ok {
+				if info.Source == "builtin" {
+					info.Agents = appendUniqueStrings(info.Agents, tmpl.dirName)
+					info.Runtimes = unionSorted(info.Runtimes, tmpl.runtimes)
+					if info.Description == "" {
+						info.Description = description
+					}
+				}
+				continue
+			}
+			skills[name] = &SkillInfo{
+				Name:        name,
+				Description: description,
+				Source:      "builtin",
+				Agents:      []string{tmpl.dirName},
+				Runtimes:    append([]string{}, tmpl.runtimes...),
+			}
+		}
+	}
+
+	// Shared half: directory entries under agents/global/skills/. A listing
+	// failure (prefix absent, storage down) degrades to an empty shared set
+	// rather than failing the whole catalog. Directory entries only (mc ls
+	// marks them with a trailing "/"); bare files and dot-entries are
+	// non-skill artifacts. Builtin names win on collision.
+	if h.oss != nil {
+		if entries, err := h.oss.ListObjects(r.Context(), globalSkillsPrefix); err == nil {
+			for _, raw := range entries {
+				if !strings.HasSuffix(raw, "/") {
+					continue
+				}
+				name := strings.TrimSuffix(raw, "/")
+				if name == "" || strings.HasPrefix(name, ".") {
+					continue
+				}
+				if _, ok := skills[name]; ok {
+					continue
+				}
+				skills[name] = &SkillInfo{
+					Name:     name,
+					Source:   "shared",
+					Runtimes: append([]string{}, service.AllWorkerRuntimes...),
+				}
+			}
+		}
+	}
+
+	list := make([]SkillInfo, 0, len(skills))
+	for _, info := range skills {
+		sort.Strings(info.Agents)
+		sort.Strings(info.Runtimes)
+		list = append(list, *info)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+
+	httputil.WriteJSON(w, http.StatusOK, SkillListResponse{Skills: list, Total: len(list)})
+}
+
+// builtinTemplate is one template directory and the runtimes it seeds.
+type builtinTemplate struct {
+	dir      string // absolute template dir
+	dirName  string // directory name (as reported in SkillInfo.Agents)
+	runtimes []string
+}
+
+// builtinTemplates derives the template→runtime mapping from
+// service.BuiltinAgentDir — the same function the Deployer uses to seed
+// workers — so the catalog's per-runtime availability can never drift from
+// what workers actually receive.
+func (h *SkillsHandler) builtinTemplates() []builtinTemplate {
+	if h.workerAgentDir == "" {
+		return nil
+	}
+	byDir := map[string]*builtinTemplate{}
+	order := []string{}
+	bucket := func(dir string) *builtinTemplate {
+		b, ok := byDir[dir]
+		if !ok {
+			b = &builtinTemplate{dir: dir, dirName: filepath.Base(dir)}
+			byDir[dir] = b
+			order = append(order, dir)
+		}
+		return b
+	}
+	for _, rt := range service.AllWorkerRuntimes {
+		workerTmpl := bucket(service.BuiltinAgentDir(h.workerAgentDir, "worker", rt))
+		workerTmpl.runtimes = appendUniqueStrings(workerTmpl.runtimes, rt)
+		leaderTmpl := bucket(service.BuiltinAgentDir(h.workerAgentDir, "team_leader", rt))
+		leaderTmpl.runtimes = appendUniqueStrings(leaderTmpl.runtimes, rt)
+	}
+	out := make([]builtinTemplate, 0, len(order))
+	for _, dir := range order {
+		t := byDir[dir]
+		sort.Strings(t.runtimes)
+		out = append(out, *t)
+	}
+	return out
+}
+
+// parseSkillFrontmatter extracts name/description from the YAML frontmatter
+// of a SKILL.md. Returns ("", "") when the file or frontmatter is missing —
+// callers fall back to the directory name.
+func parseSkillFrontmatter(path string) (name, description string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", ""
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", ""
+	}
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			break
+		}
+		if v, ok := strings.CutPrefix(trimmed, "name:"); ok {
+			name = strings.TrimSpace(v)
+		} else if v, ok := strings.CutPrefix(trimmed, "description:"); ok {
+			description = strings.TrimSpace(v)
+		}
+	}
+	return name, description
+}
+
+func appendUniqueStrings(list []string, s string) []string {
+	for _, v := range list {
+		if v == s {
+			return list
+		}
+	}
+	return append(list, s)
+}
+
+// unionSorted merges two string slices, dropping duplicates.
+func unionSorted(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range append(append([]string{}, a...), b...) {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/agentteams-controller/internal/server/skills_handler.go
+++ b/agentteams-controller/internal/server/skills_handler.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/httputil"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
@@ -34,12 +35,12 @@ const globalSkillsPrefix = "agents/global/skills/"
 type SkillInfo struct {
 	Name         string             `json:"name"`
 	Description  string             `json:"description,omitempty"`
-	Source       string             `json:"source"` // "builtin" | "shared"
-	Version      string             `json:"version,omitempty"` // builtin only: SKILL.md frontmatter version
+	Source       string             `json:"source"`                 // "builtin" | "shared"
+	Version      string             `json:"version,omitempty"`      // builtin only: SKILL.md frontmatter version
 	Requirements *SkillRequirements `json:"requirements,omitempty"` // builtin only: frontmatter requires block
-	UpdatedAt    string             `json:"updated_at,omitempty"` // shared only: last listing timestamp (RFC3339 UTC)
-	Agents       []string           `json:"agents,omitempty"`   // builtin only: template dirs providing the skill
-	Runtimes     []string           `json:"runtimes,omitempty"` // runtimes for which the skill is available
+	UpdatedAt    string             `json:"updated_at,omitempty"`   // shared only: last listing timestamp (RFC3339 UTC)
+	Agents       []string           `json:"agents,omitempty"`       // builtin only: template dirs providing the skill
+	Runtimes     []string           `json:"runtimes,omitempty"`     // runtimes for which the skill is available
 }
 
 // SkillRequirements mirrors the SKILL.md "requires" declaration
@@ -83,7 +84,20 @@ func NewSkillsHandler(workerAgentDir string, o oss.StorageClient) *SkillsHandler
 }
 
 // ListSkills handles GET /api/v1/skills.
+//
+// Access: admin (L1) only. The catalog exposes the deployment-level
+// ("individual") skill layer, which is managed by the admin. Non-admin
+// callers (L2 humans, team leaders, workers, manager) are meant to use the
+// team-scoped catalog (?team=) that ships with the team-skills work; no
+// team scope exists yet, so they are rejected with a self-explanatory 400
+// instead of a silent partial view.
 func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
+	caller := auth.CallerFromContext(r.Context())
+	if caller == nil || caller.Role != auth.RoleAdmin {
+		httputil.WriteError(w, http.StatusBadRequest, "team scope required")
+		return
+	}
+
 	skills := map[string]*SkillInfo{}
 
 	for _, tmpl := range h.builtinTemplates() {

--- a/agentteams-controller/internal/server/skills_handler.go
+++ b/agentteams-controller/internal/server/skills_handler.go
@@ -37,6 +37,7 @@ type SkillInfo struct {
 	Source       string             `json:"source"` // "builtin" | "shared"
 	Version      string             `json:"version,omitempty"` // builtin only: SKILL.md frontmatter version
 	Requirements *SkillRequirements `json:"requirements,omitempty"` // builtin only: frontmatter requires block
+	UpdatedAt    string             `json:"updated_at,omitempty"` // shared only: last listing timestamp (RFC3339 UTC)
 	Agents       []string           `json:"agents,omitempty"`   // builtin only: template dirs providing the skill
 	Runtimes     []string           `json:"runtimes,omitempty"` // runtimes for which the skill is available
 }
@@ -69,8 +70,9 @@ type SkillListResponse struct {
 // workers) plus the deployment-wide shared skills staged under
 // agents/global/skills/. It never reads skill content beyond the SKILL.md
 // frontmatter (name/description/version/requires) of builtin skills; the
-// shared half is name-only by design (list-on-read, no per-skill object
-// fetches — shared SKILL.md metadata is a v2 candidate).
+// shared half is name + listing timestamp by design (list-on-read, no
+// per-skill object fetches — shared SKILL.md metadata such as description,
+// version, and requires is a v2 candidate).
 type SkillsHandler struct {
 	workerAgentDir string
 	oss            oss.StorageClient
@@ -130,10 +132,13 @@ func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
 	// failure (prefix absent, storage down) degrades to an empty shared set
 	// rather than failing the whole catalog. Directory entries only (mc ls
 	// marks them with a trailing "/"); bare files and dot-entries are
-	// non-skill artifacts. Builtin names win on collision.
+	// non-skill artifacts. Builtin names win on collision. Shared entries
+	// carry UpdatedAt from the listing when the backend exposes it (the mc
+	// ls line date; "" when unparseable) — no per-skill object fetch.
 	if h.oss != nil {
-		if entries, err := h.oss.ListObjects(r.Context(), globalSkillsPrefix); err == nil {
-			for _, raw := range entries {
+		if entries, err := h.oss.ListObjectsDetailed(r.Context(), globalSkillsPrefix); err == nil {
+			for _, entry := range entries {
+				raw := entry.Name
 				if !strings.HasSuffix(raw, "/") {
 					continue
 				}
@@ -145,9 +150,10 @@ func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				skills[name] = &SkillInfo{
-					Name:     name,
-					Source:   "shared",
-					Runtimes: append([]string{}, service.AllWorkerRuntimes...),
+					Name:      name,
+					Source:    "shared",
+					UpdatedAt: entry.UpdatedAt,
+					Runtimes:  append([]string{}, service.AllWorkerRuntimes...),
 				}
 			}
 		}

--- a/agentteams-controller/internal/server/skills_handler.go
+++ b/agentteams-controller/internal/server/skills_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/httputil"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
+	"gopkg.in/yaml.v3"
 )
 
 // globalSkillsPrefix is the deployment-wide skill staging area maintained by
@@ -31,11 +32,29 @@ const globalSkillsPrefix = "agents/global/skills/"
 // identity/availability only — never skill content, credentials, or
 // registry connection details.
 type SkillInfo struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
-	Source      string   `json:"source"` // "builtin" | "shared"
-	Agents      []string `json:"agents,omitempty"`   // builtin only: template dirs providing the skill
-	Runtimes    []string `json:"runtimes,omitempty"` // runtimes for which the skill is available
+	Name         string             `json:"name"`
+	Description  string             `json:"description,omitempty"`
+	Source       string             `json:"source"` // "builtin" | "shared"
+	Version      string             `json:"version,omitempty"` // builtin only: SKILL.md frontmatter version
+	Requirements *SkillRequirements `json:"requirements,omitempty"` // builtin only: frontmatter requires block
+	Agents       []string           `json:"agents,omitempty"`   // builtin only: template dirs providing the skill
+	Runtimes     []string           `json:"runtimes,omitempty"` // runtimes for which the skill is available
+}
+
+// SkillRequirements mirrors the SKILL.md "requires" declaration
+// (top-level or under metadata.{openclaw,qwenpaw,clawdbot}): the binaries,
+// env vars, and MCP server names the skill needs at runtime. The three
+// metadata namespaces are the conventions the OpenClaw, QwenPaw, and
+// Clawdbot runtimes each honour when parsing skill frontmatter. The catalog
+// exposes them so workbenches can warn before assignment; enforcement is
+// runtime-dependent (the qwenpaw 2.2.x registry gates skill activation on
+// require_bins/envs/mcps; other runtimes in AllWorkerRuntimes have no
+// equivalent gate yet, so a satisfied declaration is necessary but not
+// sufficient there).
+type SkillRequirements struct {
+	RequireBins []string `json:"require_bins,omitempty"`
+	RequireEnvs []string `json:"require_envs,omitempty"`
+	RequireMcps []string `json:"require_mcps,omitempty"`
 }
 
 // SkillListResponse is the payload of GET /api/v1/skills.
@@ -49,7 +68,9 @@ type SkillListResponse struct {
 // from service.BuiltinAgentDir, the same function the Deployer uses to seed
 // workers) plus the deployment-wide shared skills staged under
 // agents/global/skills/. It never reads skill content beyond the SKILL.md
-// frontmatter (name/description) of builtin skills.
+// frontmatter (name/description/version/requires) of builtin skills; the
+// shared half is name-only by design (list-on-read, no per-skill object
+// fetches — shared SKILL.md metadata is a v2 candidate).
 type SkillsHandler struct {
 	workerAgentDir string
 	oss            oss.StorageClient
@@ -73,7 +94,7 @@ func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
 			if !entry.IsDir() {
 				continue
 			}
-			name, description := parseSkillFrontmatter(filepath.Join(skillRoot, entry.Name(), "SKILL.md"))
+			name, description, version, requirements := parseSkillFrontmatter(filepath.Join(skillRoot, entry.Name(), "SKILL.md"))
 			if name == "" {
 				name = entry.Name()
 			}
@@ -84,15 +105,23 @@ func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
 					if info.Description == "" {
 						info.Description = description
 					}
+					if info.Version == "" {
+						info.Version = version
+					}
+					if info.Requirements == nil {
+						info.Requirements = requirements
+					}
 				}
 				continue
 			}
 			skills[name] = &SkillInfo{
-				Name:        name,
-				Description: description,
-				Source:      "builtin",
-				Agents:      []string{tmpl.dirName},
-				Runtimes:    append([]string{}, tmpl.runtimes...),
+				Name:         name,
+				Description:  description,
+				Version:      version,
+				Requirements: requirements,
+				Source:       "builtin",
+				Agents:       []string{tmpl.dirName},
+				Runtimes:     append([]string{}, tmpl.runtimes...),
 			}
 		}
 	}
@@ -176,30 +205,139 @@ func (h *SkillsHandler) builtinTemplates() []builtinTemplate {
 	return out
 }
 
-// parseSkillFrontmatter extracts name/description from the YAML frontmatter
-// of a SKILL.md. Returns ("", "") when the file or frontmatter is missing —
-// callers fall back to the directory name.
-func parseSkillFrontmatter(path string) (name, description string) {
+// requirementsNamespaces are the provider metadata namespaces QwenPaw 2.2.x
+// honours for the skill "requires" block (store.py
+// _REQUIREMENTS_METADATA_NAMESPACES). Kept in sync with the worker-side
+// parser so catalog declarations match runtime enforcement.
+var requirementsNamespaces = []string{"openclaw", "qwenpaw", "clawdbot"}
+
+// parseSkillFrontmatter extracts the catalog-relevant fields from the YAML
+// frontmatter of a SKILL.md: name, description, version (top-level or under
+// metadata), and the "requires" block (top-level, or under
+// metadata.{openclaw,qwenpaw,clawdbot}). Returns zero values when the file or
+// frontmatter is missing — callers fall back to the directory name. The
+// parser is intentionally lenient: malformed frontmatter yields whatever
+// fields decode cleanly, mirroring the worker-side tolerance.
+func parseSkillFrontmatter(path string) (name, description, version string, requirements *SkillRequirements) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", ""
+		return "", "", "", nil
 	}
-	lines := strings.Split(string(data), "\n")
+	block := frontmatterBlock(string(data))
+	if block == "" {
+		return "", "", "", nil
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(block), &doc); err != nil {
+		return "", "", "", nil
+	}
+	strVal := func(v any) string {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+		return ""
+	}
+	name = strVal(doc["name"])
+	description = strVal(doc["description"])
+	version = strVal(doc["version"])
+	if version == "" {
+		if meta, ok := doc["metadata"].(map[string]any); ok {
+			version = strVal(meta["version"])
+		}
+	}
+	requirements = parseRequires(doc)
+	return name, description, version, requirements
+}
+
+// frontmatterBlock returns the text between the leading "---" line and the
+// next "---" line, or "" when the file has no frontmatter.
+func frontmatterBlock(content string) string {
+	lines := strings.Split(content, "\n")
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return "", ""
+		return ""
 	}
+	var fm []string
 	for _, line := range lines[1:] {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "---" {
-			break
+		if strings.TrimSpace(line) == "---" {
+			return strings.Join(fm, "\n")
 		}
-		if v, ok := strings.CutPrefix(trimmed, "name:"); ok {
-			name = strings.TrimSpace(v)
-		} else if v, ok := strings.CutPrefix(trimmed, "description:"); ok {
-			description = strings.TrimSpace(v)
+		fm = append(fm, line)
+	}
+	return ""
+}
+
+// parseRequires resolves the "requires" declaration with the same precedence
+// as QwenPaw 2.2.x: metadata.{openclaw,qwenpaw,clawdbot}.requires first,
+// then metadata.requires, then top-level requires. A bare list is shorthand
+// for bins. Returns nil when no requires block is declared or it carries no
+// usable entries.
+func parseRequires(doc map[string]any) *SkillRequirements {
+	var raw any
+	if meta, ok := doc["metadata"].(map[string]any); ok {
+		for _, ns := range requirementsNamespaces {
+			if p, ok := meta[ns].(map[string]any); ok {
+				if r, ok := p["requires"]; ok && r != nil {
+					raw = r
+					break
+				}
+			}
+		}
+		if raw == nil {
+			if r, ok := meta["requires"]; ok {
+				raw = r
+			}
 		}
 	}
-	return name, description
+	if raw == nil {
+		raw = doc["requires"]
+	}
+	if raw == nil {
+		return nil
+	}
+	req := &SkillRequirements{}
+	take := func(v any) []string {
+		var out []string
+		switch t := v.(type) {
+		case []any:
+			for _, x := range t {
+				out = append(out, stringItems(x)...)
+			}
+		case string:
+			out = append(out, t)
+		}
+		seen := map[string]bool{}
+		var res []string
+		for _, s := range out {
+			s = strings.TrimSpace(s)
+			if s != "" && !seen[s] {
+				seen[s] = true
+				res = append(res, s)
+			}
+		}
+		return res
+	}
+	switch t := raw.(type) {
+	case []any:
+		req.RequireBins = take(t)
+	case map[string]any:
+		req.RequireBins = take(t["bins"])
+		req.RequireEnvs = take(t["env"])
+		req.RequireMcps = take(t["mcp"])
+	}
+	if len(req.RequireBins) == 0 && len(req.RequireEnvs) == 0 && len(req.RequireMcps) == 0 {
+		return nil
+	}
+	sort.Strings(req.RequireBins)
+	sort.Strings(req.RequireEnvs)
+	sort.Strings(req.RequireMcps)
+	return req
+}
+
+func stringItems(v any) []string {
+	if s, ok := v.(string); ok {
+		return []string{s}
+	}
+	return nil
 }
 
 func appendUniqueStrings(list []string, s string) []string {

--- a/agentteams-controller/internal/server/skills_handler_test.go
+++ b/agentteams-controller/internal/server/skills_handler_test.go
@@ -1,0 +1,251 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss/ossfake"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
+)
+
+func writeSkill(t *testing.T, dir, name, description string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + description + "\n---\n\n# " + name + "\n"
+	if err := os.WriteFile(filepath.Join(dir, name, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// newSkillsRig builds a template tree:
+//
+//	base/worker-agent/skills/{file-sync,find-skills}
+//	base/copaw-worker-agent/skills/{file-sync,task-progress}
+//	base/team-leader-agent/skills/{leader-briefing}
+//	(no hermes dir; a stray non-dir file in worker-agent/skills)
+//
+// and a shared OSS store:
+//
+//	agents/global/skills/shared-kb/SKILL.md   (directory entry → listed)
+//	agents/global/skills/file-sync/SKILL.md   (collides with builtin → builtin wins)
+//	agents/global/skills/notes.txt            (bare file → skipped)
+//	agents/global/skills/.hidden/SKILL.md     (dot-entry → skipped)
+func newSkillsRig(t *testing.T) (*SkillsHandler, *mcLikeOSS, string) {
+	t.Helper()
+	base := t.TempDir()
+	writeSkill(t, filepath.Join(base, "worker-agent", "skills"), "file-sync", "Sync files with centralized storage.")
+	writeSkill(t, filepath.Join(base, "worker-agent", "skills"), "find-skills", "Discover skills from the open ecosystem.")
+	if err := os.WriteFile(filepath.Join(base, "worker-agent", "skills", "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSkill(t, filepath.Join(base, "copaw-worker-agent", "skills"), "file-sync", "Sync files with centralized storage (copaw).")
+	writeSkill(t, filepath.Join(base, "copaw-worker-agent", "skills"), "task-progress", "Report task progress.")
+	writeSkill(t, filepath.Join(base, "team-leader-agent", "skills"), "leader-briefing", "Brief team members.")
+
+	store := ossfake.NewMemory()
+	mustPut := func(key string) {
+		t.Helper()
+		if err := store.PutObject(context.Background(), key, []byte("---\nname: x\n---\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustPut(globalSkillsPrefix + "shared-kb/SKILL.md")
+	mustPut(globalSkillsPrefix + "file-sync/SKILL.md")
+	mustPut(globalSkillsPrefix + "notes.txt")
+	mustPut(globalSkillsPrefix + ".hidden/SKILL.md")
+
+	fakeOSS := &mcLikeOSS{Memory: store}
+	dir := filepath.Join(base, "worker-agent")
+	return NewSkillsHandler(dir, fakeOSS), fakeOSS, base
+}
+
+func getSkills(t *testing.T, h *SkillsHandler) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil)
+	rec := httptest.NewRecorder()
+	h.ListSkills(rec, req)
+	return rec
+}
+
+func decodeSkills(t *testing.T, rec *httptest.ResponseRecorder) []SkillInfo {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp SkillListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp.Skills
+}
+
+func skillByName(t *testing.T, skills []SkillInfo, name string) SkillInfo {
+	t.Helper()
+	for _, s := range skills {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("skill %q not in catalog: %v", name, skills)
+	return SkillInfo{}
+}
+
+// TestSkillsCatalogGolden covers the builtin half (per-runtime availability
+// derived from service.BuiltinAgentDir) and the shared half (directory
+// entries under agents/global/skills/ only).
+func TestSkillsCatalogGolden(t *testing.T) {
+	h, _, _ := newSkillsRig(t)
+	skills := decodeSkills(t, getSkills(t, h))
+
+	wantNames := []string{"file-sync", "find-skills", "leader-briefing", "shared-kb", "task-progress"}
+	var gotNames []string
+	for _, s := range skills {
+		gotNames = append(gotNames, s.Name)
+	}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("names = %v, want %v", gotNames, wantNames)
+	}
+
+	// builtin provided by two templates → union of both templates' runtimes
+	// (default worker template serves every runtime except copaw/hermes;
+	// copaw template serves copaw; hermes dir absent so hermes is missing)
+	fs := skillByName(t, skills, "file-sync")
+	if fs.Source != "builtin" {
+		t.Errorf("file-sync source = %q, want builtin", fs.Source)
+	}
+	wantAgents := []string{"copaw-worker-agent", "worker-agent"}
+	if !reflect.DeepEqual(fs.Agents, wantAgents) {
+		t.Errorf("file-sync agents = %v, want %v", fs.Agents, wantAgents)
+	}
+	wantRuntimes := []string{"copaw", "deepseek-harness", "openclaw", "openhuman", "qwenpaw"}
+	if !reflect.DeepEqual(fs.Runtimes, wantRuntimes) {
+		t.Errorf("file-sync runtimes = %v, want %v", fs.Runtimes, wantRuntimes)
+	}
+
+	fsk := skillByName(t, skills, "find-skills")
+	if want := []string{"deepseek-harness", "openclaw", "openhuman", "qwenpaw"}; !reflect.DeepEqual(fsk.Runtimes, want) {
+		t.Errorf("find-skills runtimes = %v, want %v", fsk.Runtimes, want)
+	}
+
+	tp := skillByName(t, skills, "task-progress")
+	if want := []string{"copaw"}; !reflect.DeepEqual(tp.Runtimes, want) {
+		t.Errorf("task-progress runtimes = %v, want %v", tp.Runtimes, want)
+	}
+
+	// leader template serves every runtime (leader role exists on all runtimes)
+	lb := skillByName(t, skills, "leader-briefing")
+	if want := append([]string{}, service.AllWorkerRuntimes...); !reflect.DeepEqual(lb.Runtimes, sortedCopy(want)) {
+		t.Errorf("leader-briefing runtimes = %v, want %v", lb.Runtimes, sortedCopy(want))
+	}
+	if len(lb.Agents) != 1 || lb.Agents[0] != "team-leader-agent" {
+		t.Errorf("leader-briefing agents = %v, want [team-leader-agent]", lb.Agents)
+	}
+
+	// shared half: directory entry only; builtin name wins on collision
+	sk := skillByName(t, skills, "shared-kb")
+	if sk.Source != "shared" {
+		t.Errorf("shared-kb source = %q, want shared", sk.Source)
+	}
+	if !reflect.DeepEqual(sk.Runtimes, sortedCopy(append([]string{}, service.AllWorkerRuntimes...))) {
+		t.Errorf("shared-kb runtimes = %v, want all runtimes", sk.Runtimes)
+	}
+}
+
+// TestSkillsCatalogMappingConsistency pins the catalog's template→runtime
+// derivation to service.BuiltinAgentDir: for every (role, runtime) pair the
+// catalog must credit exactly the template the Deployer would seed from.
+func TestSkillsCatalogMappingConsistency(t *testing.T) {
+	h, _, _ := newSkillsRig(t)
+	templates := h.builtinTemplates()
+	byRuntime := map[string]map[string]bool{} // runtime → set of template dirs
+	for _, tmpl := range templates {
+		for _, rt := range tmpl.runtimes {
+			if byRuntime[rt] == nil {
+				byRuntime[rt] = map[string]bool{}
+			}
+			byRuntime[rt][tmpl.dir] = true
+		}
+	}
+	for _, role := range []string{"worker", "team_leader"} {
+		for _, rt := range service.AllWorkerRuntimes {
+			want := service.BuiltinAgentDir(h.workerAgentDir, role, rt)
+			if !byRuntime[rt][want] {
+				t.Errorf("(role=%s, runtime=%s): BuiltinAgentDir = %s, but catalog does not credit it for %s",
+					role, rt, want, rt)
+			}
+		}
+	}
+}
+
+// TestSkillsCatalogFieldDiscipline asserts the response schema carries
+// identity/availability only — no content, credential, or registry fields
+// can sneak in.
+func TestSkillsCatalogFieldDiscipline(t *testing.T) {
+	h, _, _ := newSkillsRig(t)
+	rec := getSkills(t, h)
+	var payload struct {
+		Skills []map[string]any `json:"skills"`
+		Total  int              `json:"total"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Total != len(payload.Skills) {
+		t.Fatalf("total = %d, entries = %d", payload.Total, len(payload.Skills))
+	}
+	allowed := map[string]bool{"name": true, "description": true, "source": true, "agents": true, "runtimes": true}
+	for _, entry := range payload.Skills {
+		for k := range entry {
+			if !allowed[k] {
+				t.Errorf("unexpected field %q in catalog entry %v", k, entry)
+			}
+		}
+	}
+}
+
+// TestSkillsCatalogSharedDegradesOnOSSFailure: a listing failure degrades to
+// an empty shared half; the catalog still serves builtins with 200.
+func TestSkillsCatalogSharedDegradesOnOSSFailure(t *testing.T) {
+	base := t.TempDir()
+	writeSkill(t, filepath.Join(base, "worker-agent", "skills"), "file-sync", "Sync files.")
+	failing := &mcLikeOSS{Memory: ossfake.NewMemory(), failList: true}
+	h := NewSkillsHandler(filepath.Join(base, "worker-agent"), failing)
+
+	skills := decodeSkills(t, getSkills(t, h))
+	if len(skills) != 1 || skills[0].Name != "file-sync" || skills[0].Source != "builtin" {
+		t.Fatalf("skills = %v, want builtin-only [file-sync]", skills)
+	}
+}
+
+// TestSkillsCatalogNoTemplateDir: an empty workerAgentDir yields no builtins
+// but still lists shared skills.
+func TestSkillsCatalogNoTemplateDir(t *testing.T) {
+	store := ossfake.NewMemory()
+	if err := store.PutObject(context.Background(), globalSkillsPrefix+"shared-kb/SKILL.md", []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	h := NewSkillsHandler("", &mcLikeOSS{Memory: store})
+	skills := decodeSkills(t, getSkills(t, h))
+	if len(skills) != 1 || skills[0].Name != "shared-kb" || skills[0].Source != "shared" {
+		t.Fatalf("skills = %v, want shared-only [shared-kb]", skills)
+	}
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string{}, in...)
+	// simple insertion sort keeps the test dependency-free
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/agentteams-controller/internal/server/skills_handler_test.go
+++ b/agentteams-controller/internal/server/skills_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss/ossfake"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
@@ -201,7 +202,7 @@ func TestSkillsCatalogFieldDiscipline(t *testing.T) {
 	if payload.Total != len(payload.Skills) {
 		t.Fatalf("total = %d, entries = %d", payload.Total, len(payload.Skills))
 	}
-	allowed := map[string]bool{"name": true, "description": true, "source": true, "version": true, "requirements": true, "agents": true, "runtimes": true}
+	allowed := map[string]bool{"name": true, "description": true, "source": true, "version": true, "requirements": true, "updated_at": true, "agents": true, "runtimes": true}
 	for _, entry := range payload.Skills {
 		for k := range entry {
 			if !allowed[k] {
@@ -307,6 +308,33 @@ func TestSkillsCatalogFrontmatterExtension(t *testing.T) {
 	plain := skillByName(t, skills, "plain-skill")
 	if plain.Version != "" || plain.Requirements != nil {
 		t.Errorf("plain-skill = %+v, want version/requirements omitted", plain)
+	}
+}
+
+// TestSkillsCatalogSharedUpdatedAt pins that shared entries carry the
+// listing timestamp (the fake's fixed write clock) and that builtin entries
+// never do (updated_at is shared-only metadata).
+func TestSkillsCatalogSharedUpdatedAt(t *testing.T) {
+	base := t.TempDir()
+	skillRoot := filepath.Join(base, "worker-agent", "skills")
+	writeSkill(t, skillRoot, "built-in", "A builtin skill.")
+
+	fakeOSS := ossfake.NewMemory()
+	if err := fakeOSS.PutObject(context.Background(), "agents/global/skills/team-report/SKILL.md", []byte("---\nname: team-report\n---\n")); err != nil {
+		t.Fatal(err)
+	}
+	h := NewSkillsHandler(filepath.Join(base, "worker-agent"), &mcLikeOSS{Memory: fakeOSS})
+	skills := decodeSkills(t, getSkills(t, h))
+
+	shared := skillByName(t, skills, "team-report")
+	want := fakeOSS.LastWriteTime().UTC().Format(time.RFC3339)
+	if shared.UpdatedAt != want {
+		t.Errorf("shared updated_at = %q, want %q", shared.UpdatedAt, want)
+	}
+
+	builtin := skillByName(t, skills, "built-in")
+	if builtin.UpdatedAt != "" {
+		t.Errorf("builtin updated_at = %q, want omitted", builtin.UpdatedAt)
 	}
 }
 

--- a/agentteams-controller/internal/server/skills_handler_test.go
+++ b/agentteams-controller/internal/server/skills_handler_test.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss/ossfake"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
 )
@@ -70,7 +72,8 @@ func newSkillsRig(t *testing.T) (*SkillsHandler, *mcLikeOSS, string) {
 
 func getSkills(t *testing.T, h *SkillsHandler) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil)
+	req := withCaller(httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil),
+		&authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
 	rec := httptest.NewRecorder()
 	h.ListSkills(rec, req)
 	return rec
@@ -238,6 +241,49 @@ func TestSkillsCatalogNoTemplateDir(t *testing.T) {
 	if len(skills) != 1 || skills[0].Name != "shared-kb" || skills[0].Source != "shared" {
 		t.Fatalf("skills = %v, want shared-only [shared-kb]", skills)
 	}
+}
+
+// TestSkills_NonAdminNoTeam_400 locks the two-layer skill model contract:
+// the deployment-level catalog is admin (L1) only. L2 humans, team leaders,
+// workers, and the manager are meant to use the team-scoped catalog
+// (?team=), which is not available yet — so a team-less request from a
+// non-admin is rejected with a self-explanatory 400 (the positive admin
+// 200 path is covered by TestSkillsCatalogGolden; per the #1214 discipline
+// both sides are asserted).
+func TestSkills_NonAdminNoTeam_400(t *testing.T) {
+	cases := []struct {
+		name   string
+		caller *authpkg.CallerIdentity
+	}{
+		{"l2-human", &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"market-team"}}},
+		{"team-leader", &authpkg.CallerIdentity{Role: authpkg.RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"}},
+		{"worker", &authpkg.CallerIdentity{Role: authpkg.RoleWorker, Username: "alpha-worker-1"}},
+		{"manager", &authpkg.CallerIdentity{Role: authpkg.RoleManager, Username: "manager"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, _ := newSkillsRig(t)
+			req := withCaller(httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil), tc.caller)
+			rec := httptest.NewRecorder()
+			h.ListSkills(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body %s)", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "team scope required") {
+				t.Fatalf("error not self-explanatory: %s", rec.Body.String())
+			}
+		})
+	}
+
+	t.Run("no-caller", func(t *testing.T) {
+		h, _, _ := newSkillsRig(t)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil)
+		rec := httptest.NewRecorder()
+		h.ListSkills(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+	})
 }
 
 // writeSkillWithFrontmatter writes a skill dir whose SKILL.md carries the

--- a/agentteams-controller/internal/server/skills_handler_test.go
+++ b/agentteams-controller/internal/server/skills_handler_test.go
@@ -201,7 +201,7 @@ func TestSkillsCatalogFieldDiscipline(t *testing.T) {
 	if payload.Total != len(payload.Skills) {
 		t.Fatalf("total = %d, entries = %d", payload.Total, len(payload.Skills))
 	}
-	allowed := map[string]bool{"name": true, "description": true, "source": true, "agents": true, "runtimes": true}
+	allowed := map[string]bool{"name": true, "description": true, "source": true, "version": true, "requirements": true, "agents": true, "runtimes": true}
 	for _, entry := range payload.Skills {
 		for k := range entry {
 			if !allowed[k] {
@@ -236,6 +236,105 @@ func TestSkillsCatalogNoTemplateDir(t *testing.T) {
 	skills := decodeSkills(t, getSkills(t, h))
 	if len(skills) != 1 || skills[0].Name != "shared-kb" || skills[0].Source != "shared" {
 		t.Fatalf("skills = %v, want shared-only [shared-kb]", skills)
+	}
+}
+
+// writeSkillWithFrontmatter writes a skill dir whose SKILL.md carries the
+// given raw frontmatter block (unquoted, caller controls exact YAML).
+func writeSkillWithFrontmatter(t *testing.T, dir, name, frontmatter string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\n" + frontmatter + "---\n\n# " + name + "\n"
+	if err := os.WriteFile(filepath.Join(dir, name, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSkillsCatalogFrontmatterExtension covers the version + requires
+// declarations, following QwenPaw 2.2.x semantics: metadata namespace
+// requires win over top-level, a bare list is shorthand for bins, and
+// entries that declare nothing keep the fields omitted (omitempty).
+func TestSkillsCatalogFrontmatterExtension(t *testing.T) {
+	base := t.TempDir()
+	skillRoot := filepath.Join(base, "worker-agent", "skills")
+
+	writeSkillWithFrontmatter(t, skillRoot, "full-skill",
+		"name: full-skill\n"+
+			"description: Declares everything.\n"+
+			"version: 1.2.0\n"+
+			"metadata:\n"+
+			"  qwenpaw:\n"+
+			"    requires:\n"+
+			"      bins: [ffmpeg, curl]\n"+
+			"      env: [API_KEY]\n"+
+			"      mcp: [web-search]\n")
+	writeSkillWithFrontmatter(t, skillRoot, "bins-only",
+		"name: bins-only\n"+
+			"description: Top-level bare list.\n"+
+			"requires: [git, jq]\n")
+	writeSkill(t, skillRoot, "plain-skill", "Declares nothing.")
+
+	h := NewSkillsHandler(filepath.Join(base, "worker-agent"), &mcLikeOSS{Memory: ossfake.NewMemory()})
+	skills := decodeSkills(t, getSkills(t, h))
+
+	full := skillByName(t, skills, "full-skill")
+	if full.Version != "1.2.0" {
+		t.Errorf("full-skill version = %q, want 1.2.0", full.Version)
+	}
+	if full.Requirements == nil {
+		t.Fatalf("full-skill requirements = nil, want populated")
+	}
+	if want := []string{"curl", "ffmpeg"}; !reflect.DeepEqual(full.Requirements.RequireBins, want) {
+		t.Errorf("require_bins = %v, want %v", full.Requirements.RequireBins, want)
+	}
+	if want := []string{"API_KEY"}; !reflect.DeepEqual(full.Requirements.RequireEnvs, want) {
+		t.Errorf("require_envs = %v, want %v", full.Requirements.RequireEnvs, want)
+	}
+	if want := []string{"web-search"}; !reflect.DeepEqual(full.Requirements.RequireMcps, want) {
+		t.Errorf("require_mcps = %v, want %v", full.Requirements.RequireMcps, want)
+	}
+
+	bins := skillByName(t, skills, "bins-only")
+	if bins.Requirements == nil {
+		t.Fatalf("bins-only requirements = nil, want populated")
+	}
+	if want := []string{"git", "jq"}; !reflect.DeepEqual(bins.Requirements.RequireBins, want) {
+		t.Errorf("require_bins = %v, want %v", bins.Requirements.RequireBins, want)
+	}
+
+	plain := skillByName(t, skills, "plain-skill")
+	if plain.Version != "" || plain.Requirements != nil {
+		t.Errorf("plain-skill = %+v, want version/requirements omitted", plain)
+	}
+}
+
+// TestSkillsCatalogRequiresNamespacePrecedence pins the 2.2.x rule: a
+// namespace requires block shadows the top-level one.
+func TestSkillsCatalogRequiresNamespacePrecedence(t *testing.T) {
+	base := t.TempDir()
+	skillRoot := filepath.Join(base, "worker-agent", "skills")
+	writeSkillWithFrontmatter(t, skillRoot, "ns-skill",
+		"name: ns-skill\n"+
+			"description: Namespace wins.\n"+
+			"requires: [top-level-bin]\n"+
+			"metadata:\n"+
+			"  openclaw:\n"+
+			"    requires:\n"+
+			"      mcp: [ns-mcp]\n")
+	h := NewSkillsHandler(filepath.Join(base, "worker-agent"), &mcLikeOSS{Memory: ossfake.NewMemory()})
+	skills := decodeSkills(t, getSkills(t, h))
+
+	ns := skillByName(t, skills, "ns-skill")
+	if ns.Requirements == nil {
+		t.Fatal("ns-skill requirements = nil")
+	}
+	if len(ns.Requirements.RequireBins) != 0 {
+		t.Errorf("require_bins = %v, want empty (namespace shadows top-level)", ns.Requirements.RequireBins)
+	}
+	if want := []string{"ns-mcp"}; !reflect.DeepEqual(ns.Requirements.RequireMcps, want) {
+		t.Errorf("require_mcps = %v, want %v", ns.Requirements.RequireMcps, want)
 	}
 }
 

--- a/agentteams-controller/internal/service/builtin_templates.go
+++ b/agentteams-controller/internal/service/builtin_templates.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"path/filepath"
+
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/backend"
+)
+
+// AllWorkerRuntimes is the full set of supported worker runtimes (mirrors
+// the backend.Runtime* constants). The skill catalog uses it to derive the
+// template→runtime mapping from BuiltinAgentDir.
+var AllWorkerRuntimes = []string{
+	backend.RuntimeOpenClaw,
+	backend.RuntimeCopaw,
+	backend.RuntimeHermes,
+	backend.RuntimeOpenHuman,
+	backend.RuntimeQwenPaw,
+	backend.RuntimeDeepSeekHarness,
+}
+
+// BuiltinAgentDir returns the agent template directory that seeds the given
+// (role, runtime) pair. It is the single source of truth for template
+// selection: the Deployer seeds SOUL.md / AGENTS.md / builtin skills from
+// this directory, and the read-only skill catalog derives its
+// template→runtime availability mapping from the same function, so the two
+// can never drift apart.
+func BuiltinAgentDir(workerAgentDir, role, runtime string) string {
+	baseDir := filepath.Dir(workerAgentDir)
+	switch role {
+	case "team_leader":
+		return filepath.Join(baseDir, "team-leader-agent")
+	default:
+		switch runtime {
+		case backend.RuntimeCopaw:
+			return filepath.Join(baseDir, "copaw-worker-agent")
+		case backend.RuntimeHermes:
+			return filepath.Join(baseDir, "hermes-worker-agent")
+		}
+		return workerAgentDir
+	}
+}

--- a/agentteams-controller/internal/service/deployer.go
+++ b/agentteams-controller/internal/service/deployer.go
@@ -1495,19 +1495,7 @@ func (d *Deployer) pushBuiltinTopLevelFiles(ctx context.Context, workerName, age
 }
 
 func (d *Deployer) builtinAgentDir(role, runtime string) string {
-	baseDir := filepath.Dir(d.workerAgentDir)
-	switch role {
-	case "team_leader":
-		return filepath.Join(baseDir, "team-leader-agent")
-	default:
-		switch runtime {
-		case "copaw":
-			return filepath.Join(baseDir, "copaw-worker-agent")
-		case "hermes":
-			return filepath.Join(baseDir, "hermes-worker-agent")
-		}
-		return d.workerAgentDir
-	}
+	return BuiltinAgentDir(d.workerAgentDir, role, runtime)
 }
 
 // mergeUserPluginConfig preserves user-customized plugin entries from an

--- a/docs/design/skill-catalog-api.md
+++ b/docs/design/skill-catalog-api.md
@@ -1,0 +1,139 @@
+# Skill Catalog API
+
+Status: implemented
+API: `GET /api/v1/skills`
+
+## Problem
+
+The workbench (and any API client) needs a browsable catalog of the skills a
+team can assign to its workers. Before this endpoint there was no way to
+list them through the controller API — the Dashboard Skill Center reads its
+own private storage, which user-facing clients cannot reach, and the Worker
+CRD only records what is already assigned, not what is available.
+
+The catalog answers two questions:
+
+1. **Which built-in skills exist, and for which runtimes?** Built-in skills
+   are seeded into `agents/<worker>/skills/` at provisioning time by the
+   deployer, from role/runtime-specific agent template directories. A skill
+   shipped by the `copaw` template, for example, is only available to copaw
+   workers — the catalog must say so, or clients will offer assignments that
+   silently no-op.
+2. **Which skills are staged for deployment-wide distribution?** The
+   dashboard's skill-upload flow stages skills under
+   `agents/global/skills/`; they can be distributed to any worker from the
+   dashboard or via `PUT /workers` (`skills` field).
+
+## Design
+
+A single read-only endpoint, `GET /api/v1/skills`, served by a
+`SkillsHandler` with two halves:
+
+1. **Builtin skills.** The handler scans the agent-template directories the
+   deployer uses when provisioning workers. The template→runtime mapping is
+   **derived from `service.BuiltinAgentDir`** — the same function the
+   deployer calls — by iterating every supported runtime
+   (`service.AllWorkerRuntimes`) for the worker and team-leader roles. The
+   catalog therefore cannot drift from what workers actually receive: if the
+   deployer's template selection changes, the catalog's per-runtime
+   availability changes with it, automatically. Each
+   `skills/<skill>/SKILL.md` frontmatter contributes `name` and
+   `description`; the directory name is the fallback name. The same skill
+   shipped by several templates is reported once, with the providing
+   templates listed in `agents` and the union of their runtimes in
+   `runtimes`.
+2. **Shared skills.** The handler lists the first level of
+   `agents/global/skills/` (read-only, on each request). Directory entries
+   are skills; bare files and dot-entries are skipped. Builtin names win on
+   collision. A listing failure (prefix absent, storage down) degrades to an
+   empty shared set — the catalog still serves builtins with `200`.
+
+### Retention semantics of the shared prefix
+
+`agents/global/skills/` is a **staging area, not a distribution channel**:
+no worker entrypoint consumes this prefix automatically. A shared skill
+reaches a worker only through per-worker distribution (dashboard Worker
+dialog, or L1/L2 `PUT /workers` `skills`), which also records the
+assignment in `spec.skills`. Consequently, deleting
+`agents/global/skills/{name}/`:
+
+- removes the skill from this catalog and from the dashboard's global area, and
+- does **not** touch already-distributed per-worker copies
+  (`agents/<worker>/skills/{name}/`) or existing `spec.skills`
+  assignments — there is no cascade. A worker whose assignment is later
+  removed stops receiving the skill at its next sync/refresh.
+
+### No content access
+
+Only frontmatter metadata of builtin skills is read (shared skills are
+listed by name only in v1). Skill bodies and registry credentials are never
+exposed; the endpoint performs no registry calls. The response schema is
+deliberately limited to `name` / `description` / `source` / `agents` /
+`runtimes` (pinned by `TestSkillsCatalogFieldDiscipline`).
+
+## Contract
+
+`GET /api/v1/skills` → `200`
+
+```json
+{
+  "skills": [
+    {"name": "file-sync", "description": "Sync files with centralized storage.", "source": "builtin", "agents": ["copaw-worker-agent", "worker-agent"], "runtimes": ["copaw", "deepseek-harness", "openclaw", "openhuman", "qwenpaw"]},
+    {"name": "shared-kb", "source": "shared", "runtimes": ["copaw", "deepseek-harness", "hermes", "openclaw", "openhuman", "qwenpaw"]}
+  ],
+  "total": 2
+}
+```
+
+- `source` is `"builtin"` or `"shared"`.
+- `agents` is present for builtin skills (sorted, deduplicated template
+  directory names).
+- `runtimes` is sorted. For builtin skills it is the set of runtimes whose
+  template ships the skill; for shared skills it is the full runtime list
+  (any worker can be given a shared skill via per-worker distribution).
+- Output is sorted by `name`; missing template directories (deployment
+  without some runtimes) are silently skipped.
+- Errors: none expected; a backend read failure degrades to the remaining
+  half. No `4xx` paths.
+
+### Known limitation (tracked, out of v1)
+
+`deepseek-harness` workers do not currently consume MinIO-seeded or
+`spec.skills`-assigned skills: the dsh runtime prepares skills from its
+in-image plugin manifest, so the runtime.yaml skill section is a no-op there.
+The catalog still lists dsh in `runtimes` because the controller does seed
+the files for dsh workers; assignments to dsh workers have no effect until
+the runtime consumes them (follow-up). Clients should badge dsh
+assignments accordingly.
+
+## Authorization
+
+`ActionList` on the `skills` resource kind. The catalog is metadata-only
+(skill names/descriptions, no PII, no credentials), so it is available to
+admins, managers, team leaders, and team-scoped humans; worker service
+accounts are denied. No scope filtering — availability is deployment-wide,
+and per-worker assignment remains a separate (write) concern via
+`PUT /workers`.
+
+## Out of scope (v1)
+
+- Registry-side listing (querying a registry for skills no worker references
+  yet) — needs registry read credentials; separate requirement.
+- Skill content download / upload (Dashboard Skill Center territory).
+- Per-worker availability (`GET /workers/{name}/skills/available`) — the
+  catalog is global metadata; per-worker truth (MinIO object existence) is a
+  follow-up.
+- Plugin-bundled skills of the qwenpaw worker image (baked into the image,
+  not assignable via `spec.skills`; a build-time manifest is a follow-up).
+
+## Tests
+
+- `internal/server/skills_handler_test.go` — golden catalog (builtin
+  dedup across templates with `agents` + `runtimes` union; shared directory
+  entries; builtin-wins-on-collision; bare files and dot-entries skipped),
+  template→runtime mapping consistency against `service.BuiltinAgentDir`
+  for every (role, runtime) pair, response field discipline (no unexpected
+  fields), shared-half degradation on OSS list failure, empty
+  `WorkerAgentDir` → shared-only catalog.
+- `internal/auth/authorizer_test.go` — authorization matrix for the
+  `skills` resource kind.

--- a/docs/design/skill-catalog-api.md
+++ b/docs/design/skill-catalog-api.md
@@ -65,11 +65,13 @@ assignment in `spec.skills`. Consequently, deleting
 
 ### No content access
 
-Only frontmatter metadata of builtin skills is read (shared skills are
-listed by name only in v1). Skill bodies and registry credentials are never
-exposed; the endpoint performs no registry calls. The response schema is
-deliberately limited to `name` / `description` / `source` / `agents` /
-`runtimes` (pinned by `TestSkillsCatalogFieldDiscipline`).
+Only frontmatter metadata of builtin skills is read
+(`name` / `description` / `version` / `requires`); shared skills are listed
+by name + `updated_at` (the listing timestamp) only. Skill bodies and
+registry credentials are never exposed; the endpoint performs no registry
+calls. The response schema is deliberately limited to `name` /
+`description` / `source` / `version` / `requirements` / `updated_at` /
+`agents` / `runtimes` (pinned by `TestSkillsCatalogFieldDiscipline`).
 
 ## Contract
 
@@ -78,14 +80,27 @@ deliberately limited to `name` / `description` / `source` / `agents` /
 ```json
 {
   "skills": [
-    {"name": "file-sync", "description": "Sync files with centralized storage.", "source": "builtin", "agents": ["copaw-worker-agent", "worker-agent"], "runtimes": ["copaw", "deepseek-harness", "openclaw", "openhuman", "qwenpaw"]},
-    {"name": "shared-kb", "source": "shared", "runtimes": ["copaw", "deepseek-harness", "hermes", "openclaw", "openhuman", "qwenpaw"]}
+    {"name": "file-sync", "description": "Sync files with centralized storage.", "source": "builtin", "version": "1.0.0", "requirements": {"require_bins": ["mc"]}, "agents": ["copaw-worker-agent", "worker-agent"], "runtimes": ["copaw", "deepseek-harness", "openclaw", "openhuman", "qwenpaw"]},
+    {"name": "shared-kb", "source": "shared", "updated_at": "2026-09-11T08:00:00Z", "runtimes": ["copaw", "deepseek-harness", "hermes", "openclaw", "openhuman", "qwenpaw"]}
   ],
   "total": 2
 }
 ```
 
 - `source` is `"builtin"` or `"shared"`.
+- `version` (builtin only) is the SKILL.md frontmatter `version` (top-level,
+  falling back to `metadata.version`); omitted when undeclared.
+- `requirements` (builtin only) mirrors the frontmatter `requires`
+  declaration (`require_bins` / `require_envs` / `require_mcps`), parsed
+  with QwenPaw 2.2.x semantics (`metadata.{openclaw,qwenpaw,clawdbot}.requires`
+  shadows `metadata.requires`, which shadows top-level `requires`; a bare
+  list is shorthand for `bins`). Enforcement is runtime-dependent: the
+  qwenpaw 2.2.x registry gates skill activation on it; other runtimes have
+  no equivalent gate yet — the field is exposed so workbenches can warn
+  before assignment.
+- `updated_at` (shared only, RFC3339 UTC) is the listing timestamp when the
+  backend exposes it; omitted when unparseable. Builtin entries never
+  carry it.
 - `agents` is present for builtin skills (sorted, deduplicated template
   directory names).
 - `runtimes` is sorted. For builtin skills it is the set of runtimes whose
@@ -93,8 +108,10 @@ deliberately limited to `name` / `description` / `source` / `agents` /
   (any worker can be given a shared skill via per-worker distribution).
 - Output is sorted by `name`; missing template directories (deployment
   without some runtimes) are silently skipped.
-- Errors: none expected; a backend read failure degrades to the remaining
-  half. No `4xx` paths.
+- Errors: a backend read failure degrades to the remaining half (`200`).
+  `400 team scope required` — non-admin callers: the catalog is the
+  deployment-level (individual) skill layer, L1-only (see Authorization);
+  the team-scoped read (`?team=`) follows with the team-skills work.
 
 ### Known limitation (tracked, out of v1)
 
@@ -108,12 +125,14 @@ assignments accordingly.
 
 ## Authorization
 
-`ActionList` on the `skills` resource kind. The catalog is metadata-only
-(skill names/descriptions, no PII, no credentials), so it is available to
-admins, managers, team leaders, and team-scoped humans; worker service
-accounts are denied. No scope filtering — availability is deployment-wide,
-and per-worker assignment remains a separate (write) concern via
-`PUT /workers`.
+`ActionList` on the `skills` resource kind (any other action is denied, not
+defaulted). The catalog exposes the deployment-level ("individual") skill
+layer, which is managed by the admin, so the handler enforces an **admin
+(L1) only** role gate: non-admin callers (L2 humans, team leaders, workers,
+manager) receive `400 team scope required` — the team-scoped catalog
+(`?team=`) ships with the team-skills work (tracked in #1221). The response
+is metadata-only (no PII, no credentials); per-worker assignment remains a
+separate (write) concern via `PUT /workers`.
 
 ## Out of scope (v1)
 
@@ -133,7 +152,14 @@ and per-worker assignment remains a separate (write) concern via
   entries; builtin-wins-on-collision; bare files and dot-entries skipped),
   template→runtime mapping consistency against `service.BuiltinAgentDir`
   for every (role, runtime) pair, response field discipline (no unexpected
-  fields), shared-half degradation on OSS list failure, empty
-  `WorkerAgentDir` → shared-only catalog.
+  fields), frontmatter extension (`version` + `requires` in
+  metadata-namespace / top-level / bare-list forms, namespace shadowing
+  precedence, omitempty for undeclared skills), shared `updated_at`
+  propagation (backend-supplied timestamp; builtin entries never carry
+  it), non-admin no-team rejection (L2 human / team leader / worker /
+  manager / missing caller → `400` with the self-explanatory message; the
+  positive admin `200` path is pinned by the golden test), shared-half
+  degradation on OSS list failure, empty `WorkerAgentDir` → shared-only
+  catalog.
 - `internal/auth/authorizer_test.go` — authorization matrix for the
   `skills` resource kind.

--- a/docs/usage/resource-management.md
+++ b/docs/usage/resource-management.md
@@ -137,6 +137,15 @@ All supported Dashboard distribution paths update `spec.skills`. The Controller 
 
 You can also use `spec.package` to provide a Worker package containing a `skills/` directory. Package skills and assigned skills are merged without conflict.
 
+### Skill Catalog API
+
+`GET /api/v1/skills` returns the read-only catalog of skills available in the deployment:
+
+- **`source: "builtin"`** — the skills shipped with the agent templates, with the providing templates listed in `agents` and the supporting runtimes in `runtimes` (derived from the deployer's own template selection, so the catalog never drifts from what workers actually receive).
+- **`source: "shared"`** — the skills staged under `agents/global/skills/` by the Dashboard's skill-upload flow, available for distribution to any worker. This prefix is a staging area, not a distribution channel: deleting an entry removes it from the catalog and the Dashboard's global area but never touches already-distributed per-worker copies or existing `spec.skills` assignments (no cascade).
+
+Output is sorted by name; the endpoint is metadata-only — no skill content, no registry calls, no credentials. Available to admins, managers, team leaders, and team-scoped humans. See [Skill Catalog API](../design/skill-catalog-api.md).
+
 ### Worker with Custom Package
 
 ```yaml

--- a/docs/usage/resource-management.md
+++ b/docs/usage/resource-management.md
@@ -144,7 +144,7 @@ You can also use `spec.package` to provide a Worker package containing a `skills
 - **`source: "builtin"`** — the skills shipped with the agent templates, with the providing templates listed in `agents` and the supporting runtimes in `runtimes` (derived from the deployer's own template selection, so the catalog never drifts from what workers actually receive).
 - **`source: "shared"`** — the skills staged under `agents/global/skills/` by the Dashboard's skill-upload flow, available for distribution to any worker. This prefix is a staging area, not a distribution channel: deleting an entry removes it from the catalog and the Dashboard's global area but never touches already-distributed per-worker copies or existing `spec.skills` assignments (no cascade).
 
-Output is sorted by name; the endpoint is metadata-only — no skill content, no registry calls, no credentials. Available to admins, managers, team leaders, and team-scoped humans. See [Skill Catalog API](../design/skill-catalog-api.md).
+Output is sorted by name; the endpoint is metadata-only — no skill content, no registry calls, no credentials. Entries carry `name`/`description`/`source` plus `version`/`requirements` (builtin) and `updated_at` (shared). Available to **admin (L1) only**; non-admin callers receive `400 team scope required` (the team-scoped read `?team=` follows). See [Skill Catalog API](../design/skill-catalog-api.md).
 
 ### Worker with Custom Package
 

--- a/docs/zh-cn/usage/resource-management.md
+++ b/docs/zh-cn/usage/resource-management.md
@@ -137,6 +137,15 @@ Manager 会先上传并验证 `SKILL.md`，再更新 `spec.skills`。QwenPaw Wor
 
 也可以通过 `spec.package` 引入一个包含 `skills/` 目录的 Worker 包。包内 Skills 与按名称分配的 Skills 会合并，互不冲突。
 
+### 技能目录 API
+
+`GET /api/v1/skills` 返回部署中可用技能的只读目录，含两类：
+
+- **`source: "builtin"`**——agent 模板自带的内置技能（取自各 `SKILL.md` frontmatter 的 name + description，`agents` 列出提供该技能的模板，`runtimes` 列出支持的运行时）。模板→运行时的映射取自 deployer 自身的 `BuiltinAgentDir` 选择逻辑，因此目录永远与 Worker 实际接收的内置技能一致、不会漂移。
+- **`source: "shared"`**——Dashboard 技能上传流程暂存到 `agents/global/skills/` 下的技能，可分发到任意 Worker。该前缀是**暂存区而非分发通道**：删除其中某个条目只会把它从目录和 Dashboard 全局区移除，**不会**触碰已分发的 per-worker 副本或既有的 `spec.skills` 分配（无级联）。
+
+输出按名称排序；端点只暴露元数据——不读技能正文、不访问注册表、不泄露凭据。admin、manager、团队 Leader、团队范围人类用户均可访问。设计见 [Skill Catalog API](../design/skill-catalog-api.md)。
+
 ### 带自定义包的 Worker
 
 ```yaml

--- a/docs/zh-cn/usage/resource-management.md
+++ b/docs/zh-cn/usage/resource-management.md
@@ -144,7 +144,7 @@ Manager 会先上传并验证 `SKILL.md`，再更新 `spec.skills`。QwenPaw Wor
 - **`source: "builtin"`**——agent 模板自带的内置技能（取自各 `SKILL.md` frontmatter 的 name + description，`agents` 列出提供该技能的模板，`runtimes` 列出支持的运行时）。模板→运行时的映射取自 deployer 自身的 `BuiltinAgentDir` 选择逻辑，因此目录永远与 Worker 实际接收的内置技能一致、不会漂移。
 - **`source: "shared"`**——Dashboard 技能上传流程暂存到 `agents/global/skills/` 下的技能，可分发到任意 Worker。该前缀是**暂存区而非分发通道**：删除其中某个条目只会把它从目录和 Dashboard 全局区移除，**不会**触碰已分发的 per-worker 副本或既有的 `spec.skills` 分配（无级联）。
 
-输出按名称排序；端点只暴露元数据——不读技能正文、不访问注册表、不泄露凭据。admin、manager、团队 Leader、团队范围人类用户均可访问。设计见 [Skill Catalog API](../design/skill-catalog-api.md)。
+输出按名称排序；端点只暴露元数据——不读技能正文、不访问注册表、不泄露凭据。条目含 `name`/`description`/`source` 及 `version`/`requirements`（builtin）与 `updated_at`（shared）。**仅 admin（L1）可访问**；非 admin 调用方收到 `400 team scope required`（团队范围读 `?team=` 后续交付）。设计见 [Skill Catalog API](../design/skill-catalog-api.md)。
 
 ### 带自定义包的 Worker
 


### PR DESCRIPTION
## Maintainer architecture clarification / 维护者结构设计说明

The skill catalog is designed to aggregate three independent source categories:

1. **Controller-bundled builtin skills**: metadata read from the local skill templates shipped with the Controller. This PR scans the role/runtime agent templates; coverage of the separate on-demand `worker-skills/` directory is a follow-up.
2. **Global shared skill staging area in object storage**: metadata listed from `agents/global/skills/` using the configured Controller storage client.
3. **Configured external skill centers, such as Nacos**: a future catalog source queried through the configured skill-center integration and its read credentials. This PR does not implement external-center enumeration; it must not reconstruct that catalog from existing Worker `remoteSkills` assignments or expose credentials.

This PR is the first increment and implements sources 1 and 2 within the coverage described above. Source 3 belongs to the overall architecture and is deferred, not excluded from the design. External-source identity, access scope, collision handling, and failure behavior will be specified with that integration rather than assumed to be implemented here.

The end-to-end flow is: **query candidate skills → user selection → update Worker assignments → deliver skill files → runtime loading**. This endpoint owns only the first step. Catalog inclusion is not proof that a particular Worker already has or has loaded a skill; distribution and runtime support remain separate concerns. Completing that downstream flow is not a prerequisite for this read-only catalog increment.

技能目录按三类独立数据源设计：

1. **Controller 自带内置 Skill**：读取 Controller 随附的本地技能模板元数据。本 PR 扫描角色/运行时 Agent 模板；独立的按需 `worker-skills/` 目录覆盖作为后续补充。
2. **对象存储中的全局共享技能暂存区**：通过 Controller 已配置的存储客户端列举 `agents/global/skills/`。
3. **配置的外置 Skill 中心，例如 Nacos**：后续通过配置的技能中心集成及读取凭据查询。当前 PR 尚未实现外置中心目录枚举，不应从已有 Worker 的 `remoteSkills` 分配状态反推目录，也不得暴露凭据。

本 PR 作为第一阶段，在上述覆盖范围内实现前两类；第三类属于整体结构设计，后续接入。外置来源标识、访问范围、同名处理与故障行为应在接入时明确，不将其描述为当前已实现能力。

完整链路为：**查询候选技能 → 用户选择 → 更新 Worker 分配 → 技能文件到达 Worker → 运行时加载**。本接口只负责第一步。出现在目录中，不代表某个 Worker 已收到或加载该技能；分发和运行时支持是后续环节，不要求在这个只读目录 PR 中一并完成。

---

# Read-only skill catalog endpoint

## Summary

There was no controller API for listing which skills a deployment makes available to workers. The Dashboard Skill Center reads its own private storage (unreachable by user-facing clients), and the Worker CRD only records skills already assigned, not what is available to assign. Workbench UIs that let a team manage its workers' capabilities had no catalog to browse.

This PR adds `GET /api/v1/skills`, a single read-only endpoint that returns:

- **Builtin skills** (`source: "builtin"`) — scanned from the agent-template directories the deployer uses when provisioning workers. Each `skills/<skill>/SKILL.md` frontmatter contributes `name`, `description`, `version` (top-level, falling back to `metadata.version`), and `requirements` (`require_bins` / `require_envs` / `require_mcps`, parsed with QwenPaw 2.2.x semantics: `metadata.{openclaw,qwenpaw,clawdbot}.requires` shadows `metadata.requires`, which shadows top-level `requires`; a bare list is shorthand for `bins`); the directory name is the fallback. Enforcement of `requirements` is runtime-dependent (the qwenpaw 2.2.x registry gates skill activation on it; other runtimes in `AllWorkerRuntimes` have no equivalent gate yet) — the catalog exposes the declarations so workbenches can warn before assignment. A skill shipped by several templates is reported once, with the providing templates in `agents`. Crucially, **per-runtime availability is derived from `service.BuiltinAgentDir`** — the same function the deployer calls — by iterating every supported runtime (`service.AllWorkerRuntimes`) for the worker and team-leader roles, so the catalog can never drift from what workers actually receive. A copaw-template builtin is only offered for copaw runtimes, and so on.
- **Shared skills** (`source: "shared"`) — the first-level directory listing of `agents/global/skills/`, the Dashboard's skill staging prefix. Directory entries only (bare files and dot-entries are skipped); builtin names win on collision. Each entry reports `updated_at` (the listing timestamp when the backend exposes it, RFC3339 UTC, omitted when unparseable) — no per-skill object fetch. This prefix is a **staging area, not a distribution channel**: no worker entrypoint consumes it automatically, and deleting an entry removes it from the catalog and the Dashboard's global area only — already-distributed per-worker copies and `spec.skills` assignments are never touched (no cascade).

The endpoint is metadata-only: no skill content, no registry calls, no credentials. Output is sorted by name.

## What's included

- `internal/server/skills_handler.go` (new) — catalog assembly (builtin scan with per-runtime mapping + shared listing) and a small SKILL.md frontmatter parser.
- `internal/service/builtin_templates.go` (new) — `BuiltinAgentDir` (extracted from `Deployer.builtinAgentDir`, which now delegates to it) and `AllWorkerRuntimes`: the single source of truth for template selection, shared by the deployer and the catalog.
- `internal/server/http.go` — `GET /api/v1/skills` route; handler wired with `WorkerAgentDir` + the existing `OSS` storage client.
- `internal/auth/authorizer.go` — new `skills` resource kind: exactly `ActionList` granted (any other action on this resource is denied, not defaulted) for humans and team leaders; worker service accounts denied. The L1-only role gate lives in the handler (see Authorization below).
- `docs/design/skill-catalog-api.md` — design contract (incl. retention semantics + known-limitation note).
- `docs/usage/resource-management.md` (+ zh-cn) — API reference section.

## Data boundary

- No new resources, no CRD or schema change, no write paths.
- No external network I/O: the shared half is a single object-store listing call against the controller's own MinIO; a failure degrades to an empty shared set (`200`, builtins still served).
- Frontmatter parsing reads `name`/`description`/`version`/`requires` (builtin, via `yaml.v3`); shared skills are listed by name + `updated_at` only — `description`/`version`/`requirements` are omitted for them by design (list-on-read, no per-skill object fetches; shared SKILL.md metadata is a v2 candidate). Skill bodies are never returned; the response field set is pinned to `name`/`description`/`source`/`version`/`requirements`/`updated_at`/`agents`/`runtimes` by `TestSkillsCatalogFieldDiscipline`. `StorageClient` gains `ListObjectsDetailed` so the listing can carry the timestamp without any extra round trip (mc ls lines already include the date).
- Missing template directories (deployments without some runtimes) are skipped silently.
- Authorization: the catalog exposes the deployment-level (individual) skill layer, which is managed by the admin. The handler enforces an **admin (L1) only** role gate: non-admin callers (L2 humans, team leaders, workers, manager) get a self-explanatory `400 team scope required` — the team-scoped catalog (`?team=`) ships with the team-skills work tracked in #1221. The response is metadata-only (no PII); per-worker assignment remains a separate write concern via `PUT /workers`.

## Known limitation (documented, out of v1)

`deepseek-harness` workers do not currently consume MinIO-seeded or `spec.skills`-assigned skills (the dsh runtime preps skills from its in-image plugin manifest instead), so the catalog lists dsh in `runtimes` — reflecting what the controller seeds — while noting that assignments to dsh workers no-op until the runtime consumes them.

Cross-runtime name collision: `find-skills`, `mcporter`, and `file-sync` are shipped by multiple template dirs with **differing content per runtime** (verified by diff: SKILL.md differs; file-sync even carries different scripts). The catalog dedups by name, so the entry's `description`/`version`/`requirements` reflect the first-scanned template variant (the default `worker-agent` template, which serves openclaw/openhuman/qwenpaw/dsh) — accurate for 4 of the 6 runtimes; hermes- and copaw-legacy-variant metadata is a representative value, not the runtime's actual one. Per-runtime variant metadata is a v2 candidate (see #1221 follow-ups).

Real directory sizes are not reported: MinIO directory entries are virtual (0-byte markers), so a non-recursive listing cannot yield a skill's byte size; per-skill `size` would require a recursive listing (v2 candidate). `updated_at` uses the mc ls line date, interpreted in the mc process zone (UTC in the reference deployment); mc format drift degrades the field to empty rather than failing the listing.

## Tests

- `internal/server/skills_handler_test.go` (new): golden catalog (cross-template dedup with `agents` + `runtimes` union; shared directory entries; builtin-wins-on-collision; bare files and dot-entries skipped); template→runtime **mapping consistency against `service.BuiltinAgentDir` for every (role, runtime) pair**; response field discipline; frontmatter extension (version + `requires` in metadata-namespace / top-level / bare-list forms, namespace shadowing precedence, omitempty for undeclared skills); shared `updated_at` propagation (backend-supplied timestamp, builtin entries never carry it); shared-half degradation on OSS list failure; empty `WorkerAgentDir` → shared-only catalog.
- Non-admin no-team rejection (`TestSkills_NonAdminNoTeam_400`): L2 human / team leader / worker / manager / missing caller → `400` with the self-explanatory message; the positive admin `200` path is pinned by the golden test (positive+negative test discipline).
- `internal/auth/authorizer_test.go` — authorization matrix for the `skills` resource kind.
- `go test ./...` green (all internal packages). `gofmt`/`go vet` clean.

## Related

- Re-scoped per the 2026-09-05 skill-management research (plugin 技能中心 design v0.3): v1 scope is **builtin + shared only**; registry-side listing (needs registry read credentials), per-worker availability, the qwenpaw in-image bundled-skill manifest, and coverage of the separate on-demand `worker-skills/` directory are documented follow-ups.
- Complements the project/worker read endpoints for workbench UIs: the catalog (this PR) tells a team what it can assign; assignment itself stays on the existing worker/team write paths (#1212).
- Design: `docs/design/skill-catalog-api.md`. Related: #1221 (Skill Center architecture) · #1220 (permission model — catalog schema incl. `version`/`requirements` recorded in its §10).

---

# 只读技能目录端点

## 摘要

此前没有任何 Controller API 可以列出部署中可用的技能。Dashboard Skill Center 读的是它自己的私有存储（用户侧客户端够不到），Worker CRD 只记录已分配的技能，不是可分配目录。需要管理团队技能配置的工作台 UI 没有候选池可浏览。

本 PR 新增 `GET /api/v1/skills`，单一只读端点，返回两类技能：

- **内置技能**（`source: "builtin"`）— 从 deployer provisioning Worker 时使用的同一套 agent 模板目录扫描。每个 `skills/<skill>/SKILL.md` frontmatter 提供 `name`、`description`、`version`（顶层，兜底 `metadata.version`）与 `requirements`（`require_bins` / `require_envs` / `require_mcps`，按 QwenPaw 2.2.x 语义解析：`metadata.{openclaw,qwenpaw,clawdbot}.requires` 遮蔽 `metadata.requires`，后者遮蔽顶层 `requires`；裸列表 = `bins` 简写），目录名兜底。`requirements` 的执行是运行时相关的（qwenpaw 2.2.x 注册表以它门控技能启用；`AllWorkerRuntimes` 中其他运行时尚无等价门控）——目录暴露声明供工作台在分配前警告。多个模板都带的技能只报告一次，`agents` 列出提供它的模板。关键是 **per-runtime 可用性取自 `service.BuiltinAgentDir`**——deployer 调用的是同一个函数——遍历全部受支持运行时（`service.AllWorkerRuntimes`）× worker/team-leader 两个角色推导，目录与 Worker 实际接收的内置技能永不漂移：copaw 模板的技能只对 copaw 运行时开放，以此类推。
- **共享技能**（`source: "shared"`）— `agents/global/skills/`（Dashboard 技能暂存前缀）的一级目录列表。仅目录条目（裸文件与点条目跳过）；同名时 builtin 优先。每条带 `updated_at`（后端可提供的列表时间戳，RFC3339 UTC，解析失败则省略）——不逐技能取对象。该前缀是**暂存区而非分发通道**：没有 Worker 入口自动消费它；删除某个条目只从目录和 Dashboard 全局区移除，**不触碰**已分发的 per-worker 副本与既有 `spec.skills` 分配（无级联）。

端点只暴露元数据：不返回技能正文、不访问注册表、不泄露凭据。输出按名称排序。

## 包含内容

- `internal/server/skills_handler.go`（新）— 目录组装（内置扫描 + per-runtime 映射 + 共享列表）与小型 SKILL.md frontmatter 解析器。
- `internal/service/builtin_templates.go`（新）— `BuiltinAgentDir`（从 `Deployer.builtinAgentDir` 提取，原方法改为委托调用）与 `AllWorkerRuntimes`：模板选择的唯一事实源，deployer 与目录共用。
- `internal/server/http.go` — `GET /api/v1/skills` 路由；handler 接线 `WorkerAgentDir` + 既有 `OSS` 存储客户端。
- `internal/auth/authorizer.go` — 新 `skills` 资源类型：仅授予 `ActionList`（其他 action 一律拒绝、不走默认放行），human/team-leader 可 list，worker 服务账号拒绝；L1-only 角色门在 handler 层（见鉴权）。
- `docs/design/skill-catalog-api.md` — 设计契约（含 retention 语义与已知限制说明）。
- `docs/usage/resource-management.md`（+ zh-cn）— API 参考节。

## 数据边界

- 无新资源、无 CRD/schema 变更、无写路径。
- 零外部网络 I/O：共享半边是对 Controller 自身 MinIO 的单次对象列表调用；失败退化为空共享集（`200`，内置照常返回）。
- frontmatter 解析读 `name`/`description`/`version`/`requires`（内置，经 `yaml.v3`）；共享技能只按名称 + `updated_at` 列出——`version`/`requirements` 对其按设计省略（list-on-read，不逐技能取对象；共享技能的 SKILL.md 元数据是 v2 候选）。技能正文永不返回；响应字段集由 `TestSkillsCatalogFieldDiscipline` 钉死为 `name`/`description`/`source`/`version`/`requirements`/`updated_at`/`agents`/`runtimes`。
- 模板目录缺失（部署不含某些 runtime）静默跳过。
- 鉴权：目录暴露的是部署级（单独层）技能，由 admin 管理。handler 强制 **admin（L1）only** 角色门：非 admin 调用方（L2 人类用户 / 团队 Leader / Worker / Manager）收到自解释的 `400 team scope required`——团队范围目录（`?team=`）随 #1221 跟踪的 team-skills 工作交付。响应只含元数据（无 PII）；按 Worker 分配仍是独立的写操作（`PUT /workers`）。

## 已知限制（已文档化，不在 v1 范围）

`deepseek-harness` Worker 目前不消费 MinIO 种子或 `spec.skills` 分配的技能（dsh 运行时改用镜像内插件清单准备技能），因此目录在 `runtimes` 中列出 dsh（反映 Controller 的种子行为），并文档注明：在运行时消费之前，分配给 dsh Worker 的技能不生效。

跨运行时同名冲突：`find-skills`、`mcporter`、`file-sync` 由多个模板目录提供且**内容逐运行时不同**（diff 实查：SKILL.md 有差异；file-sync 的脚本文件都不同）。目录按名去重，条目的 `description`/`version`/`requirements` 取首个扫描到的模板变体（默认 `worker-agent` 模板，服务 openclaw/openhuman/qwenpaw/dsh）——对 6 个运行时中的 4 个是精确值；hermes 与 copaw-legacy 变体的元数据是代表值而非该运行时的实际值。per-runtime 变体元数据是 v2 候选（见 #1221 follow-ups）。

## 测试

- `internal/server/skills_handler_test.go`（新）：golden 目录（跨模板去重 + `agents`/`runtimes` 并集；共享目录条目；同名 builtin 优先；裸文件与点条目跳过）；模板→运行时**映射与 `service.BuiltinAgentDir` 对每个 (role, runtime) 组合的一致性**；响应字段纪律；frontmatter 扩展（version + `requires` 的 metadata-namespace / 顶层 / 裸列表三形态、namespace 遮蔽优先级、未声明技能 omitempty）；OSS 列表失败时共享半边降级；空 `WorkerAgentDir` → 仅共享目录。
- 非 admin 无团队拒绝（`TestSkills_NonAdminNoTeam_400`）：L2 人类 / 团队 Leader / Worker / Manager / 无 caller → `400` + 自解释消息；正向 admin `200` 由 golden 测试钉死（正负双必配）。
- `internal/auth/authorizer_test.go` — `skills` 资源类型的鉴权矩阵。
- `go test ./...` 全绿（全部 internal 包）。`gofmt`/`go vet` 干净。

## 相关

- 按 2026-09-05 技能管理调研（插件技能中心设计 v0.3）re-scope：v1 范围 = **builtin + shared**；注册表侧列表（需注册表读凭据）、per-worker 可用性、qwenpaw 镜像内置技能清单、独立按需 `worker-skills/` 目录覆盖均为文档化后续项。
- 与项目/Worker 读端点互补：目录（本 PR）告诉团队能分配什么，分配本身仍走既有 worker/team 写路径（#1212）。
- 设计文档：`docs/design/skill-catalog-api.md`。相关：#1221（Skill Center 架构）· #1220（权限模型——目录 schema 含 `version`/`requirements` 已记入其 §10）。

