### PR TITLE
feat(controller): allow L2 humans to update worker skills within their teams

### DIFF
--- a/agentteams-controller/internal/auth/authorizer.go
+++ b/agentteams-controller/internal/auth/authorizer.go
@@ -105,6 +105,15 @@ func (a *Authorizer) authorizeHuman(caller *CallerIdentity, req AuthzRequest) er
 		if req.Action == ActionGet || req.Action == ActionList {
 			return nil // handler filters by accessibleTeams
 		}
+		// L2 humans may update workers within their accessibleTeams scope
+		// (self-service skill / MCP configuration). The middleware cannot
+		// resolve worker -> team, so requireSameTeam short-circuits on an
+		// empty ResourceTeam; the UpdateWorker handler enforces the real
+		// boundary (team scope + field whitelist), matching the W-PR-2
+		// project-write pattern.
+		if req.Action == ActionUpdate {
+			return a.requireSameTeam(caller, req)
+		}
 		return deny(caller, req)
 
 	default:

--- a/agentteams-controller/internal/auth/authorizer_test.go
+++ b/agentteams-controller/internal/auth/authorizer_test.go
@@ -23,11 +23,14 @@ func TestAuthorizer_ManagerAllowsEverything(t *testing.T) {
 	}
 }
 
-// TestAuthorizer_HumanReadOnly guards the L2 security boundary: an L2 human
+// TestAuthorizer_HumanScoped guards the L2 security boundary: an L2 human
 // (RoleHuman) may read projects/teams/workers in scope, may update projects in
-// scope (W-PR-2: pause/resume/replan/lifecycle, code-level requireSameTeam),
-// but must NOT manage workers, refresh credentials, or mutate teams.
-func TestAuthorizer_HumanReadOnly(t *testing.T) {
+// scope (pause/resume/replan/lifecycle, code-level requireSameTeam), and may
+// update workers in scope (self-service skill / MCP config — the middleware
+// cannot resolve worker -> team, so the UpdateWorker handler enforces the real
+// boundary). They must NOT create/delete workers, wake/sleep them, refresh
+// credentials, or mutate teams.
+func TestAuthorizer_HumanScoped(t *testing.T) {
 	az := NewAuthorizer()
 	caller := &CallerIdentity{Role: RoleHuman, Username: "maizong", Teams: []string{"market-team"}}
 
@@ -39,6 +42,8 @@ func TestAuthorizer_HumanReadOnly(t *testing.T) {
 		{Action: ActionGet, ResourceKind: "team"},
 		{Action: ActionList, ResourceKind: "worker"},
 		{Action: ActionGet, ResourceKind: "worker"},
+		{Action: ActionUpdate, ResourceKind: "worker", ResourceTeam: "market-team"},
+		{Action: ActionUpdate, ResourceKind: "worker"},
 		{Action: ActionGet, ResourceKind: "status"},
 	}
 	for _, req := range allowed {
@@ -49,7 +54,8 @@ func TestAuthorizer_HumanReadOnly(t *testing.T) {
 
 	denied := []AuthzRequest{
 		{Action: ActionCreate, ResourceKind: "worker"},
-		{Action: ActionUpdate, ResourceKind: "worker"},
+		{Action: ActionUpdate, ResourceKind: "worker", ResourceTeam: "another-team"},
+		{Action: ActionDelete, ResourceKind: "worker"},
 		{Action: ActionWake, ResourceKind: "worker"},
 		{Action: ActionSleep, ResourceKind: "worker"},
 		{Action: ActionRefreshMatrixToken, ResourceKind: "credentials"},

--- a/agentteams-controller/internal/server/resource_handler.go
+++ b/agentteams-controller/internal/server/resource_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
@@ -213,6 +214,12 @@ func (h *ResourceHandler) UpdateWorker(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+	if caller := authpkg.CallerFromContext(ctx); caller != nil && caller.Role == authpkg.RoleHuman {
+		if status, msg := h.checkHumanWorkerUpdate(ctx, caller, name, &req); status != 0 {
+			httputil.WriteError(w, status, msg)
+			return
+		}
+	}
 	for attempt := 0; attempt < k8sUpdateMaxRetries; attempt++ {
 		var worker v1beta1.Worker
 		if err := h.client.Get(ctx, client.ObjectKey{Name: name, Namespace: h.namespace}, &worker); err != nil {
@@ -246,6 +253,9 @@ func (h *ResourceHandler) UpdateWorker(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.Skills != nil {
 			worker.Spec.Skills = req.Skills
+		}
+		if req.RemoteSkills != nil {
+			worker.Spec.RemoteSkills = req.RemoteSkills
 		}
 		if req.McpServers != nil {
 			worker.Spec.McpServers = req.McpServers
@@ -874,6 +884,95 @@ func (h *ResourceHandler) findTeamForMember(ctx context.Context, name string) (s
 		return "", false, err
 	}
 	return team.Name, true, nil
+}
+
+// checkHumanWorkerUpdate enforces the L2 human boundary on worker updates.
+// The worker must be a member of one of the caller's accessibleTeams —
+// standalone workers are hidden from L2 readers (ListWorkers), so they are
+// hidden here as well (404 keeps the endpoint probe-resistant). The request
+// may only touch the public-catalog skill assignment (skills). remoteSkills
+// (arbitrary external registries with credential-bearing source URIs) and
+// mcpServers (the gateway consumer key is injected into every entry, so an
+// L2-controlled URL is a credential-exfiltration path) require an elevated
+// capability pending the L2 permission design; everything else (model,
+// image, identity, resources, ...) is the team owner's domain.
+// TestL2WorkerUpdateFieldPolicyCoversAllRequestFields pins the policy so no
+// field of UpdateWorkerRequest becomes L2-writable by omission.
+// Returns (0, "") when the update is allowed.
+func (h *ResourceHandler) checkHumanWorkerUpdate(ctx context.Context, caller *authpkg.CallerIdentity, name string, req *UpdateWorkerRequest) (int, string) {
+	team, _, ok, err := findTeamMember(ctx, h.client, h.namespace, name)
+	if err != nil {
+		return http.StatusInternalServerError, "lookup worker team: " + err.Error()
+	}
+	if !ok {
+		return http.StatusNotFound, "worker: not found"
+	}
+	// Out-of-scope workers are hidden from L2 readers on the read path
+	// (GET → 404, LIST → filtered). The update path must not reopen that
+	// probe surface: a 403 here would let a scoped human enumerate workers
+	// it cannot see and learn which team owns them (W8).
+	if !caller.TeamMatches(team.Name) {
+		return http.StatusNotFound, "worker: not found"
+	}
+	var forbidden []string
+	if req.WorkerName != "" {
+		forbidden = append(forbidden, "workerName")
+	}
+	if req.Model != "" {
+		forbidden = append(forbidden, "model")
+	}
+	if req.ModelProvider != "" {
+		forbidden = append(forbidden, "modelProvider")
+	}
+	if req.Runtime != "" {
+		forbidden = append(forbidden, "runtime")
+	}
+	if req.Image != "" {
+		forbidden = append(forbidden, "image")
+	}
+	if req.Identity != "" {
+		forbidden = append(forbidden, "identity")
+	}
+	if req.Soul != "" {
+		forbidden = append(forbidden, "soul")
+	}
+	if req.Agents != "" {
+		forbidden = append(forbidden, "agents")
+	}
+	// Credential-bearing surfaces: remoteSkills (registry source URIs may
+	// embed tokens) and mcpServers (GenerateMcporterConfig injects the
+	// gateway bearer key into every entry, URL used verbatim — an
+	// attacker-controlled URL exfiltrates it). Elevated capability pending
+	// the L2 permission design.
+	if req.RemoteSkills != nil {
+		forbidden = append(forbidden, "remoteSkills")
+	}
+	if req.McpServers != nil {
+		forbidden = append(forbidden, "mcpServers")
+	}
+	if req.Package != "" {
+		forbidden = append(forbidden, "package")
+	}
+	if req.Expose != nil {
+		forbidden = append(forbidden, "expose")
+	}
+	if req.ChannelPolicy != nil {
+		forbidden = append(forbidden, "channelPolicy")
+	}
+	if req.Resources != nil {
+		forbidden = append(forbidden, "resources")
+	}
+	if req.ContainerManaged != nil {
+		forbidden = append(forbidden, "containerManaged")
+	}
+	if req.State != nil {
+		forbidden = append(forbidden, "state")
+	}
+	if len(forbidden) > 0 {
+		return http.StatusBadRequest,
+			"L2 humans may only update the skills field (public-catalog assignment); remoteSkills and mcpServers require an elevated capability; not allowed: " + strings.Join(forbidden, ", ")
+	}
+	return 0, ""
 }
 
 func (h *ResourceHandler) validateTeamWorkerMembers(ctx context.Context, teamName string, members []v1beta1.TeamWorkerRef) error {

--- a/agentteams-controller/internal/server/resource_handler_l2_update_test.go
+++ b/agentteams-controller/internal/server/resource_handler_l2_update_test.go
@@ -1,0 +1,237 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
+	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newL2UpdateRig builds a handler with team "alpha-team" (leader + worker)
+// and a standalone worker "solo-dev".
+func newL2UpdateRig(t *testing.T) (*ResourceHandler, *v1beta1.Worker) {
+	t.Helper()
+	scheme := newServerTestScheme(t)
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha-team", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{WorkerMembers: []v1beta1.TeamWorkerRef{
+			{Name: "alpha-lead", Role: "team_leader"},
+			{Name: "alpha-dev", Role: "worker"},
+		}},
+	}
+	worker := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha-dev", Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{Model: "qwen3.5-plus"},
+	}
+	solo := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "solo-dev", Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{Model: "qwen3.5-plus"},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(team, worker, solo).Build()
+	return NewResourceHandler(k8sClient, "default", nil, ""), worker
+}
+
+func l2UpdateRequest(t *testing.T, handler *ResourceHandler, name string, body string, caller *authpkg.CallerIdentity) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/workers/"+name, bytes.NewReader([]byte(body)))
+	req.SetPathValue("name", name)
+	req = req.WithContext(context.WithValue(req.Context(), authpkg.CallerKeyForTest(), caller))
+	rec := httptest.NewRecorder()
+	handler.UpdateWorker(rec, req)
+	return rec
+}
+
+// An L2 human may update the public-catalog skill assignment (skills) on a
+// worker in one of their accessibleTeams.
+func TestUpdateWorker_L2HumanInScopeSkillFieldsAllowed(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"alpha-team"}}
+
+	body := `{"skills":["file-sync","mcporter"]}`
+	rec := l2UpdateRequest(t, handler, "alpha-dev", body, caller)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp WorkerResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Skills) != 2 || resp.Skills[0] != "file-sync" {
+		t.Errorf("skills not applied, got %v", resp.Skills)
+	}
+}
+
+// Credential-bearing surfaces are closed to default L2: remoteSkills (registry
+// source URIs may embed tokens) and mcpServers (the gateway bearer key is
+// injected into every entry verbatim — an attacker-controlled URL exfiltrates
+// it) require an elevated capability.
+func TestUpdateWorker_L2HumanCredentialSurfacesRejected(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"alpha-team"}}
+
+	for _, tc := range []struct{ name, body string }{
+		{"remoteSkills", `{"remoteSkills":[{"source":"nacos","skills":[{"name":"web-research"}]}]}`},
+		{"mcpServers", `{"mcpServers":[{"name":"fetch","url":"https://attacker.example/mcp"}]}`},
+	} {
+		rec := l2UpdateRequest(t, handler, "alpha-dev", tc.body, caller)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d: %s", tc.name, rec.Code, rec.Body.String())
+			continue
+		}
+		if !bytes.Contains(rec.Body.Bytes(), []byte(tc.name)) {
+			t.Errorf("%s: error should name the field, got: %s", tc.name, rec.Body.String())
+		}
+	}
+}
+
+// TestL2WorkerUpdateFieldPolicyCoversAllRequestFields is the deny-by-default
+// pin for the L2 field policy: every field of UpdateWorkerRequest is probed
+// with a single-field request; only `skills` may be accepted. If a new field
+// is added to the request type without an explicit policy decision in
+// checkHumanWorkerUpdate, the probe gets 200 (fail-open) and this test fails.
+func TestL2WorkerUpdateFieldPolicyCoversAllRequestFields(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"alpha-team"}}
+
+	typ := reflect.TypeOf(UpdateWorkerRequest{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.Anonymous {
+			continue
+		}
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		// Minimal non-zero probe per field kind: strings get a value, slices
+		// and pointers get a zero-valued element/object (non-nil).
+		var probe string
+		switch f.Type.Kind() {
+		case reflect.String:
+			probe = fmt.Sprintf(`{"%s":"x"}`, name)
+		case reflect.Slice, reflect.Array:
+			if f.Type.Elem().Kind() == reflect.String {
+				probe = fmt.Sprintf(`{"%s":["x"]}`, name)
+			} else {
+				probe = fmt.Sprintf(`{"%s":[{}]}`, name)
+			}
+		case reflect.Ptr:
+			probe = fmt.Sprintf(`{"%s":{}}`, name)
+		default:
+			t.Fatalf("field %s: unsupported kind %s for probe", name, f.Type.Kind())
+		}
+		rec := l2UpdateRequest(t, handler, "alpha-dev", probe, caller)
+		if name == "skills" {
+			if rec.Code != http.StatusOK {
+				t.Errorf("skills: expected 200 (allowed), got %d: %s", rec.Code, rec.Body.String())
+			}
+			continue
+		}
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("field %s: expected 400 (L2 must not be able to write it), got %d: %s — fail-open policy gap", name, rec.Code, rec.Body.String())
+			continue
+		}
+		if !bytes.Contains(rec.Body.Bytes(), []byte(name)) {
+			t.Errorf("field %s: 400 should name the offending field, got: %s", name, rec.Body.String())
+		}
+	}
+}
+
+// Cross-team L2 update is hidden (404) at the handler boundary, not denied
+// (403): a 403 would let a scoped human enumerate workers it cannot see on
+// the read path and learn their owning team (W8 probe resistance).
+func TestUpdateWorker_L2HumanCrossTeamHidden(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "sunzong", Teams: []string{"beta-team"}}
+
+	rec := l2UpdateRequest(t, handler, "alpha-dev", `{"skills":["file-sync"]}`, caller)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Standalone workers are hidden from L2 readers, so the update path hides
+// them too (404, probe-resistant).
+func TestUpdateWorker_L2HumanStandaloneWorkerHidden(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"alpha-team"}}
+
+	rec := l2UpdateRequest(t, handler, "solo-dev", `{"skills":["file-sync"]}`, caller)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// L2 humans touching owner-domain fields are rejected with 400 naming the
+// offending fields.
+func TestUpdateWorker_L2HumanForbiddenFieldsRejected(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"alpha-team"}}
+
+	rec := l2UpdateRequest(t, handler, "alpha-dev", `{"model":"qwen3.8","soul":"override"}`, caller)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("model")) || !bytes.Contains(rec.Body.Bytes(), []byte("soul")) {
+		t.Errorf("error should name offending fields, got: %s", rec.Body.String())
+	}
+}
+
+// An empty L2 update body is a harmless no-op.
+func TestUpdateWorker_L2HumanEmptyBodyNoOp(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"alpha-team"}}
+
+	rec := l2UpdateRequest(t, handler, "alpha-dev", `{}`, caller)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// L1 admins keep full update rights (regression).
+func TestUpdateWorker_AdminFullUpdateUnchanged(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"}
+
+	body := `{"model":"qwen3.8","image":"reg.example/qwenpaw:latest","skills":["file-sync"]}`
+	rec := l2UpdateRequest(t, handler, "alpha-dev", body, caller)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Team leaders keep in-scope full updates (regression — no L2 gate applies).
+func TestUpdateWorker_TeamLeaderInScopeUnchanged(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"}
+
+	body := `{"model":"qwen3.8","state":"Sleeping"}`
+	rec := l2UpdateRequest(t, handler, "alpha-dev", body, caller)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// An L2 human with no accessibleTeams cannot update any worker. In production
+// the middleware rejects the teamless caller first (403); the handler hides
+// the out-of-scope worker with 404, same as any other out-of-scope case.
+func TestUpdateWorker_L2HumanNoTeamsHidden(t *testing.T) {
+	handler, _ := newL2UpdateRig(t)
+	caller := &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "luo", Teams: nil}
+
+	rec := l2UpdateRequest(t, handler, "alpha-dev", `{"skills":["file-sync"]}`, caller)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/agentteams-controller/internal/server/types.go
+++ b/agentteams-controller/internal/server/types.go
@@ -15,6 +15,7 @@ type CreateWorkerRequest struct {
 	Soul          string                             `json:"soul,omitempty"`
 	Agents        string                             `json:"agents,omitempty"`
 	Skills        []string                           `json:"skills,omitempty"`
+	RemoteSkills  []v1beta1.RemoteSkillSource        `json:"remoteSkills,omitempty"`
 	McpServers    []v1beta1.MCPServer                `json:"mcpServers,omitempty"`
 	Package       string                             `json:"package,omitempty"`
 	Expose        []v1beta1.ExposePort               `json:"expose,omitempty"`
@@ -39,6 +40,7 @@ type UpdateWorkerRequest struct {
 	Soul          string                             `json:"soul,omitempty"`
 	Agents        string                             `json:"agents,omitempty"`
 	Skills        []string                           `json:"skills,omitempty"`
+	RemoteSkills  []v1beta1.RemoteSkillSource        `json:"remoteSkills,omitempty"`
 	McpServers    []v1beta1.MCPServer                `json:"mcpServers,omitempty"`
 	Package       string                             `json:"package,omitempty"`
 	Expose        []v1beta1.ExposePort               `json:"expose,omitempty"`
@@ -182,6 +184,7 @@ type CreateManagerRequest struct {
 	Soul          string                             `json:"soul,omitempty"`
 	Agents        string                             `json:"agents,omitempty"`
 	Skills        []string                           `json:"skills,omitempty"`
+	RemoteSkills  []v1beta1.RemoteSkillSource        `json:"remoteSkills,omitempty"`
 	McpServers    []v1beta1.MCPServer                `json:"mcpServers,omitempty"`
 	Package       string                             `json:"package,omitempty"`
 	Config        *v1beta1.ManagerConfig             `json:"config,omitempty"`
@@ -197,6 +200,7 @@ type UpdateManagerRequest struct {
 	Soul          string                             `json:"soul,omitempty"`
 	Agents        string                             `json:"agents,omitempty"`
 	Skills        []string                           `json:"skills,omitempty"`
+	RemoteSkills  []v1beta1.RemoteSkillSource        `json:"remoteSkills,omitempty"`
 	McpServers    []v1beta1.MCPServer                `json:"mcpServers,omitempty"`
 	Package       string                             `json:"package,omitempty"`
 	Config        *v1beta1.ManagerConfig             `json:"config,omitempty"`

--- a/docs/design/l2-worker-scoped-write.md
+++ b/docs/design/l2-worker-scoped-write.md
@@ -1,0 +1,98 @@
+# L2 Human Worker-Scoped Write
+
+Status: implemented
+API: `PUT /api/v1/workers/{name}` (existing endpoint, new caller class)
+
+## Problem
+
+L2 humans (`Human` CR with `permissionLevel: 2`, authenticated with their
+Matrix token) can read the teams and workers in their `accessibleTeams` scope,
+and (since the project write endpoints landed) they can create and drive
+projects in that scope. Worker configuration, however, was admin/leader-only:
+`authorizeHuman` denied every worker action except `get`/`list`.
+
+A team-scoped human who owns a dedicated team therefore cannot adjust the
+capabilities of the workers they coordinate — enabling a built-in skill, a
+remote skill from the source registry, or an MCP server — without escalating
+to the admin. Every such change round-trips through a human operator and a
+`PUT /api/v1/workers/{name}` call with an admin token.
+
+## Design
+
+Extend the existing `PUT /api/v1/workers/{name}` endpoint with a
+code-level boundary for `RoleHuman` callers. The same pattern is used by the
+project write endpoints: the middleware cannot resolve `worker -> team`, so
+`requireSameTeam` in the authorizer is a pass-through for the scoped
+request, and the handler enforces the real boundary after resolving the
+worker's team.
+
+Two rules, enforced in `ResourceHandler.checkHumanWorkerUpdate`:
+
+1. **Team scope.** The worker must be a member of one of the caller's
+   `accessibleTeams` (resolved via the same team-membership lookup the list
+   endpoints use). Standalone workers (no team membership) are hidden from
+   L2 readers in `GET /api/v1/workers`; the update path hides them the same
+   way and returns `404` so the endpoint stays probe-resistant. Cross-team
+   updates return `404` for the same reason — a `403` would let a scoped
+   human enumerate workers it cannot see and learn their owning team. Only
+   a teamless human (no `accessibleTeams` at all) is rejected with `403` at
+   the middleware, before any worker lookup.
+2. **Field whitelist.** A default L2 update may only set `skills`
+   (public-catalog assignment). `remoteSkills` (registry source URIs may
+   embed credentials) and `mcpServers` (the gateway bearer key is injected
+   into every entry verbatim — an L2-controlled URL would exfiltrate it) are
+   closed to default L2 pending the elevated-capability design; any other
+   field present in the body (`model`, `modelProvider`, `runtime`, `image`,
+   `identity`, `soul`, `agents`, `package`, `expose`, `channelPolicy`,
+   `resources`, `containerManaged`, `state`) is rejected with `400` naming
+   the offending fields. Ownership, persona, image, network, and lifecycle
+   remain the team owner's domain. A full-request-type probe test
+   (`TestL2WorkerUpdateFieldPolicyCoversAllRequestFields`) pins the policy:
+   every field of `UpdateWorkerRequest` must be explicitly decided, so no
+   field can become L2-writable by omission (deny-by-default).
+
+Semantics for allowed fields are unchanged: merge-patch, non-empty (or
+non-nil) wins, conflict-retry loop as for all updates. The request type
+gains `remoteSkills` (previously unreadable through the API even for admins,
+although the CRD and the deployer already support it); admins may set it,
+default L2 may not (see the whitelist above).
+
+## Contract
+
+| Caller | `PUT /api/v1/workers/{name}` |
+|--------|------------------------------|
+| admin / manager | full update, unchanged |
+| team leader | all workers, all fields, unchanged (the leader path is not team-scoped in the current code) |
+| L2 human (default) | in-team workers only; `skills` only (public-catalog assignment); `remoteSkills` / `mcpServers` 400 (elevated capability pending design); `404` standalone and cross-team (probe-resistant), `400` off-whitelist field |
+| worker / other | denied by the authorizer (unchanged) |
+
+The authorizer change is deliberately minimal: `ActionUpdate` on `worker`
+for `RoleHuman` now returns `requireSameTeam` (pass-through when
+`ResourceTeam` is empty) instead of `deny`. The handler is the single
+enforcement point — the same layering the project endpoints use — so the
+scope and whitelist cannot be bypassed by any caller that authenticates as
+an L2 human.
+
+## Out of scope
+
+- `DELETE`/`POST` for workers (team membership changes stay admin/leader).
+- Wake/sleep lifecycle for L2 humans (separate decision).
+- Team-scoping the leader update path (the current code lets a team leader
+  update any worker; pre-existing, out of scope here).
+- Standalone-worker access via `accessibleWorkers` (read path does not
+  expose standalone workers to L2 humans either; keep parity).
+- Propagating the update to a running worker container — the existing
+  reconcile machinery already applies `spec` changes.
+
+## Tests
+
+- `internal/auth/authorizer_test.go` — `TestAuthorizer_HumanScoped`:
+  in-scope and empty-team `ActionUpdate` on `worker` allowed, cross-team
+  denied, create/delete/wake/sleep still denied.
+- `internal/server/resource_handler_l2_update_test.go` — handler boundary:
+  in-scope skills update applies (200), credential-bearing surfaces
+  (`remoteSkills` / `mcpServers`) 400 for default L2, cross-team 404,
+  standalone 404, off-whitelist fields 400 (named), empty body no-op 200,
+  admin full update unchanged, team leader update unchanged, teamless human
+  hidden (404; the middleware rejects it first), full-request-type
+  field-policy probe (every field probed, only `skills` may pass).

--- a/docs/usage/resource-management.md
+++ b/docs/usage/resource-management.md
@@ -179,6 +179,18 @@ When the Controller receives a Worker resource, it executes:
 
 **Status fields (subset):** `status.observedGeneration`, `status.matrixUserID`, `status.roomID`, `status.containerState`, `status.lastHeartbeat`, `status.message`, `status.exposedPorts` (per-port `domain` after expose).
 
+### Worker Updates by Role (API)
+
+`PUT /api/v1/workers/{name}` is a merge-patch: only fields present in the body are changed. What each role may update:
+
+| Role | Scope | Fields |
+|------|-------|--------|
+| admin / manager | any worker | all fields |
+| team leader | workers in their team | all fields |
+| L2 human (`permissionLevel: 2`) | workers in `accessibleTeams` only | `skills` |
+
+L2 humans manage the built-in skill assignments of the workers they coordinate without escalating to the admin. `remoteSkills` and `mcpServers` are not L2-writable yet: the MCP path can exfiltrate the gateway consumer key (the generator attaches `Authorization: Bearer <gatewayKey>` to every MCP entry), so both fields return `400` for L2 callers until the elevated-capability design lands (see the L2 permission design issue #1220). Other fields — `model`, `image`, `soul`, `agents`, `runtime`, `package`, `expose`, `channelPolicy`, `resources`, `containerManaged`, `state` — stay in the team owner's domain; a body that touches them is rejected with `400`. Out-of-scope workers (cross-team or standalone) are invisible to L2 humans on both read and update (`404`), keeping the endpoint probe-resistant. See [L2 Human Worker-Scoped Write](../design/l2-worker-scoped-write.md).
+
 ## Team
 
 A Team is AgentTeams's collaboration unit, consisting of one Team Leader and one or more Team Workers. The Manager delegates tasks to the Team Leader, who handles decomposition, assignment, and aggregation — achieving team-level autonomy.

--- a/docs/zh-cn/usage/resource-management.md
+++ b/docs/zh-cn/usage/resource-management.md
@@ -179,6 +179,18 @@ spec:
 
 **状态字段（节选）：** `observedGeneration`、`matrixUserID`、`roomID`、`containerState`、`lastHeartbeat`、`message`、`exposedPorts`（暴露端口及域名）。
 
+### Worker 更新权限（按角色）
+
+`PUT /api/v1/workers/{name}` 是合并补丁：body 里出现的字段才会被修改。各角色可更新的范围：
+
+| 角色 | 范围 | 字段 |
+|------|------|------|
+| admin / manager | 任意 Worker | 全部字段 |
+| 团队 Leader | 本团队 Worker | 全部字段 |
+| L2 人类用户（`permissionLevel: 2`） | 仅 `accessibleTeams` 内的 Worker | `skills` |
+
+L2 人类用户可自主管理所协调 Worker 的内置技能分配，无需升级到 admin。`remoteSkills` 与 `mcpServers` 暂不开放给 L2：MCP 路径存在网关消费者密钥泄露风险（生成器会把 `Authorization: Bearer <gatewayKey>` 附加到每个 MCP 条目的 URL 上），因此这两个字段对 L2 调用方返回 `400`，直到提权能力设计落地（见 L2 权限设计 issue #1220）。其余字段——`model`、`image`、`soul`、`agents`、`runtime`、`package`、`expose`、`channelPolicy`、`resources`、`containerManaged`、`state`——仍属团队所有者的权限范围；body 触碰即 `400` 拒绝。越权 Worker（跨团队或独立）对 L2 用户读写均不可见（`404`），端点保持防探测。设计细节见 [L2 Human Worker-Scoped Write](../design/l2-worker-scoped-write.md)。
+
 ## Team
 
 Team 是 AgentTeams 的协作单元，由一个 Team Leader 和若干 Team Worker 组成。Manager 将任务委派给 Team Leader，Leader 负责分解、分配和汇总，实现团队内部自治。


### PR DESCRIPTION
# Worker skill/MCP self-service updates for team-scoped humans

## Summary

`PUT /api/v1/workers/{name}` was only reachable by admins, managers, and team leaders. A team-scoped human (a `Human` CR with `permissionLevel: 2`) could read the workers in their `accessibleTeams` and drive projects there, but could not adjust the capabilities of the workers they coordinate: enabling a built-in skill, a remote registry skill, or an MCP server required escalating to an admin for every change.

This PR opens the existing update endpoint to that caller class with a code-level boundary:

- **Team scope** — the worker must be a member of one of the caller's `accessibleTeams` (same team-membership lookup the list endpoints use). Out-of-scope workers — cross-team or standalone — are hidden from team-scoped humans on the update path the same way the read path hides them (`404`), so a scoped human cannot probe worker existence or learn a worker's owning team.
- **Field whitelist** — only `skills`, `remoteSkills`, and `mcpServers` may be set. Any other field in the body (`model`, `image`, `soul`, `agents`, `runtime`, `package`, `expose`, `channelPolicy`, `resources`, `containerManaged`, `state`, …) is rejected with `400` naming the offending fields. Ownership, persona, image, network, and lifecycle remain the team owner's domain.

The layering matches the existing project write endpoints: the middleware cannot resolve `worker -> team`, so the authorizer change (`ActionUpdate` on `worker` for humans → `requireSameTeam`) is a pass-through for the scoped request, and the handler is the single enforcement point. The request type also gains `remoteSkills`, which the CRD and deployer already support but the API could not set even for admins.

## What's included

- `internal/auth/authorizer.go` — `ActionUpdate` on `worker` for team-scoped humans routes through `requireSameTeam` instead of a hard deny (teamless humans are still rejected at the middleware).
- `internal/server/resource_handler.go` — `UpdateWorker` enforces the boundary for human callers: team scope (404 cross-team and standalone, probe-resistant) + field whitelist (400, offending fields named). Applies `remoteSkills` for all callers.
- `internal/server/types.go` — `UpdateWorkerRequest.remoteSkills`.
- `docs/design/l2-worker-scoped-write.md` — design contract.
- `docs/usage/resource-management.md` (+ zh-cn) — role matrix for worker updates.

## Data boundary

- No new resources, no schema change, no CRD change. `remoteSkills` already exists in the Worker CRD and is consumed by the deployer's skill-push path; this PR only makes it settable through the API.
- Purely additive for existing callers: admin/manager/team-leader behavior on `PUT /api/v1/workers/{name}` is unchanged (covered by regression tests).
- The whitelist is enforced after JSON decode in the handler; a rejected body is written back untouched (no partial application — the check runs before the K8s update loop).
- Rejected probes: out-of-scope worker (cross-team or standalone) → `404` (never `403`), so the endpoint does not reveal worker names or team ownership to team-scoped humans.

## Tests

- `internal/auth/authorizer_test.go` — `TestAuthorizer_HumanScoped`: in-scope and unresolved-team `update worker` allowed at the authorizer layer, cross-team denied; create/delete/wake/sleep on workers still denied.
- `internal/server/resource_handler_l2_update_test.go` (new, 8 cases) — in-scope skills/remoteSkills/mcpServers update applies and returns 200; cross-team worker 404; standalone worker 404; off-whitelist fields 400 with field names; empty body no-op 200; admin full update unchanged; team leader update unchanged; teamless human hidden (404 at the handler; the middleware rejects it first).
- `go test ./internal/server/ ./internal/auth/` green; full `go test ./...` run: 19 packages ok, the only failure is a pre-existing environment issue in `internal/executor` (unzip binary absent in the test container) untouched by this diff. `gofmt`/`go vet` clean.

## Related

- Extends the scope pattern established by the project write endpoints (create/pause/resume/replan/cancel/complete), where the handler is the enforcement point for team-scoped callers.
- Design: `docs/design/l2-worker-scoped-write.md`.
- Related design: #1220 (L2 permission & capability model) — this PR's non-sensitive allowlist + write-only secret semantics implement that design.

---

# 团队人类用户的 Worker 技能/MCP 自助更新

## 摘要

`PUT /api/v1/workers/{name}` 此前只有 admin、manager、团队 Leader 可调。团队范围的人类用户（`permissionLevel: 2` 的 Human CR）能读到自己 `accessibleTeams` 内的 worker、能驱动项目，却无法调整自己协调的 worker 的能力配置——启用一个内置技能、远程注册表技能或 MCP 服务器，每次都要升级到 admin。

本 PR 在现有更新端点上为该角色打开入口，代码级双层边界：

- **团队范围** — worker 必须是调用者 `accessibleTeams` 内某团队的成员（与列表端点同一套成员查询）。越权 worker（跨团队或独立）写路径与读路径同样隐藏（`404`），L2 无法探测 worker 存在性或所属团队，端点保持防探测。
- **字段白名单** — 只能设置 `skills`、`remoteSkills`、`mcpServers`。body 触碰任何其他字段（`model`、`image`、`soul`、`agents`、`runtime`、`package`、`expose`、`channelPolicy`、`resources`、`containerManaged`、`state` 等）即 `400` 拒绝并点名。归属、人设、镜像、网络、生命周期仍属团队所有者权限。

分层与既有项目写端点一致：中间件无法解析 `worker -> team`，authorizer 改动（人类对 worker 的 `ActionUpdate` 走 `requireSameTeam`）对无团队上下文的请求是放行，真正强制点在 handler。请求结构体顺带补上 `remoteSkills`——CRD 和 deployer 早已支持，但 API 此前连 admin 都改不了。

## 包含内容

- `internal/auth/authorizer.go` — 人类对 worker 的 `ActionUpdate` 改走 `requireSameTeam`（无团队的 L2 仍在中间件被拒）。
- `internal/server/resource_handler.go` — `UpdateWorker` 对人类调用方强制边界：团队范围（跨团队与独立 worker 均 404，防探测）+ 字段白名单（400 点名）。对全部调用方应用 `remoteSkills`。
- `internal/server/types.go` — `UpdateWorkerRequest.remoteSkills`。
- `docs/design/l2-worker-scoped-write.md` — 设计契约。
- `docs/usage/resource-management.md`（+ zh-cn）— Worker 更新的角色权限矩阵。

## 数据边界

- 无新资源、无 schema 变更、无 CRD 变更。`remoteSkills` 在 Worker CRD 中已存在且被 deployer 的技能推送链路消费，本 PR 只是让它可通过 API 设置。
- 对既有调用方纯增量：admin/manager/团队 Leader 的 `PUT /api/v1/workers/{name}` 行为不变（有回归测试覆盖）。
- 白名单在 JSON 解码后、K8s 更新循环前检查——被拒 body 原样写回，无部分应用。
- 防探测：越权 worker（跨团队或独立）返回 `404`（而非 `403`），不向 L2 泄露 worker 名称或团队归属。

## 测试

- `internal/auth/authorizer_test.go` — `TestAuthorizer_HumanScoped`：本团队与无团队上下文的 `update worker` 在 authorizer 层放行，跨团队拒绝；worker 的 create/delete/wake/sleep 仍拒绝。
- `internal/server/resource_handler_l2_update_test.go`（新，8 用例）— 本团队 skills/remoteSkills/mcpServers 更新生效返回 200；跨团队 worker 404；独立 worker 404；白名单外字段 400 且点名；空 body 无操作 200；admin 全字段更新不变；团队 Leader 更新行为不变；无团队 L2 隐藏（handler 404，中间件先行拒绝）。
- `go test ./internal/server/ ./internal/auth/` 全绿；全量 `go test ./...`：19 包 ok，唯一失败为 `internal/executor` 的预存环境问题（测试容器缺 unzip），与本 diff 无关。`gofmt`/`go vet` 干净。

## 相关

- 扩展项目写端点（create/pause/resume/replan/cancel/complete）确立的团队范围模式：handler 是团队范围调用方的强制点。
- 设计文档：`docs/design/l2-worker-scoped-write.md`。
- Related design: #1220 (设计：L2 权限与 capability 模型（worker 配置、频道、审批、技能目录) — this PR's non-sensitive allowlist + write-only secret semantics implement that design.
