### PR TITLE
fix(agentconfig): emit agents.list so group-chat @mention triggers reply

### DIFF
--- a/agentteams-controller/internal/agentconfig/generator.go
+++ b/agentteams-controller/internal/agentconfig/generator.go
@@ -134,6 +134,15 @@ func (g *Generator) GenerateOpenClawConfig(req WorkerConfigRequest) ([]byte, err
 			},
 		},
 		"agents": map[string]interface{}{
+			"list": []interface{}{
+				map[string]interface{}{
+					"id":       "main",
+					"name":     req.WorkerName,
+					"identity": map[string]interface{}{
+						"name": req.WorkerName,
+					},
+				},
+			},
 			"defaults": map[string]interface{}{
 				"timeoutSeconds": 1800,
 				"workspace":      "~",

--- a/agentteams-controller/internal/agentconfig/generator_test.go
+++ b/agentteams-controller/internal/agentconfig/generator_test.go
@@ -61,6 +61,21 @@ func TestGenerateOpenClawConfig_Basic(t *testing.T) {
 	if modelCfg["primary"] != "agentteams-gateway/qwen3.5-plus" {
 		t.Errorf("agents.defaults.model.primary = %v, want agentteams-gateway/qwen3.5-plus", modelCfg["primary"])
 	}
+
+	// Verify agents.list carries the worker identity so OpenClaw can build
+	// group @mention regexes (regression guard for group-chat no-reply issue).
+	list, ok := agents["list"].([]interface{})
+	if !ok || len(list) != 1 {
+		t.Fatalf("agents.list missing or wrong shape: %v", agents["list"])
+	}
+	listEntry := list[0].(map[string]interface{})
+	identity := listEntry["identity"].(map[string]interface{})
+	if listEntry["id"] != "main" {
+		t.Errorf("agents.list[0].id = %v, want main", listEntry["id"])
+	}
+	if identity["name"] != "worker-alice" {
+		t.Errorf("agents.list[0].identity.name = %v, want worker-alice", identity["name"])
+	}
 }
 
 func TestGenerateOpenClawConfig_TeamWorker(t *testing.T) {

--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -72,6 +72,13 @@
   },
 
   "agents": {
+    "list": [
+      {
+        "id": "main",
+        "name": "manager",
+        "identity": { "name": "manager" }
+      }
+    ],
     "defaults": {
       "timeoutSeconds": 1800,
       "workspace": "~",


### PR DESCRIPTION
OpenClaw derives group-chat mention regexes from agents.list[].identity.name, but GenerateOpenClawConfig only emitted agents.defaults. With an empty agents.list, buildMentionRegexes produced no patterns, wasMentioned was always false in group rooms, and the Matrix monitor dropped every room message with "skipping room message (reason: no-mention)". DMs are unaffected because DM delivery does not require a mention.

Emit agents.list with a single "main" entry whose name/identity.name is the runtime name (req.WorkerName). Apply the same fix to the Manager template (manager-openclaw.json.tmpl), which had the same gap.

Add a regression assertion in TestGenerateOpenClawConfig_Basic.

Fixes the group-chat no-reply reported in #63.