### PR TITLE
fix(controller): checkpoint proxy scoped check compared member name as team name

### DIFF
--- a/agentteams-controller/internal/server/worker_checkpoints.go
+++ b/agentteams-controller/internal/server/worker_checkpoints.go
@@ -134,15 +134,21 @@ func (h *CheckpointHandler) proxyCheckpoint(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// Resolve the owning team for the scoped-caller check (same chain as
-	// ResourceHandler.GetWorker: standalone workers hide as 404).
-	_, team, _, err := findTeamMember(r.Context(), h.client, h.namespace, name)
+	// ResourceHandler.GetWorker: standalone workers hide as 404). Note:
+	// findTeamMember's second return value is the member (worker) name,
+	// not the team name — the check must compare against the Team CR name.
+	teamObj, _, _, err := findTeamMember(r.Context(), h.client, h.namespace, name)
 	if err != nil {
 		writeK8sError(w, "get worker checkpoints", err)
 		return
 	}
+	teamName := ""
+	if teamObj != nil {
+		teamName = teamObj.Name
+	}
 	if caller := authpkg.CallerFromContext(r.Context()); caller != nil &&
 		(caller.Role == authpkg.RoleTeamLeader || caller.Role == authpkg.RoleHuman) &&
-		!caller.TeamMatches(team) {
+		!caller.TeamMatches(teamName) {
 		httputil.WriteError(w, http.StatusNotFound, "worker not found")
 		return
 	}

--- a/agentteams-controller/internal/server/worker_checkpoints_test.go
+++ b/agentteams-controller/internal/server/worker_checkpoints_test.go
@@ -236,6 +236,27 @@ func TestCheckpoint_TeamLeaderCrossTeamDenied(t *testing.T) {
 	}
 }
 
+// TestCheckpoint_L2HumanInScopeAllowed locks the scoped-caller fix:
+// findTeamMember's second return value is the member (worker) name, not
+// the team name, so the in-scope check must compare against the Team CR
+// name — an in-scope L2 human must resolve 200.
+func TestCheckpoint_L2HumanInScopeAllowed(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"commit":"abc123","date":"2026-08-31T00:00:00Z","files":[]}`))
+	}))
+	defer upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", upstream, checkpointTeamWithWorkers("market-team", "market-writer")...)
+	req := checkpointRequest(http.MethodGet, "market-writer", "graph", "")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleHuman, Username: "maizong", Teams: []string{"market-team"}})
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200 for in-scope L2 human", rec.Code, rec.Body.String())
+	}
+}
+
 func TestCheckpoint_UpstreamErrorBodyBounded(t *testing.T) {
 	big := strings.Repeat("x", 8192)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# What

4-line fix in the worker checkpoint proxy (`agentteams-controller/internal/server/worker_checkpoints.go`): the scoped-caller check now compares the caller's team against the **Team CR name** (`findTeamMember`'s first return value) instead of the **member (worker) name** (its second return value). Plus one regression test.

# Why

`findTeamMember` returns `(team *Team, memberName string, isLeader bool, err error)`. The checkpoint proxy used `memberName` in `caller.TeamMatches(...)` — but `TeamMatches` expects the **team** name. For any real team the worker's member name differs from the team name, so the check was **always false**: every team leader and every L2 human received `404` when reading checkpoints of their own team's workers, even though `#1186` documented that exact access path as supported. Cross-team callers also got `404`, so the suite (which only asserted cross-team `404`) passed for the wrong reason and never noticed.

Effect: the documented L2/leader checkpoint read path silently did not work for the roles it was built for.

# Fix

- Compare against `teamObj.Name` (first return value) — the same resolution chain as `ResourceHandler.GetWorker` and the new workspace-files proxy.
- All six `findTeamMember` call sites were audited: this was the only one misusing the member-name return value.
- Behavior change is strictly additive for in-scope callers (they now get the documented `200`); cross-team/unknown callers are unchanged (`404`, W8 anti-probing preserved).

# Test

- `TestCheckpoint_L2HumanInScopeAllowed` (new): an L2 human in the worker's own team reads its checkpoints → `200`. Before the fix this returned `404`.
- Existing cross-team `404` and leader cases still pass.
- Full `go test ./...` green on the `main` baseline (the only failure is a pre-existing environment issue in `internal/executor`: the sandbox lacks the `unzip` binary, which CI has).

# Scope

- Pure controller-side authorization logic; no worker-app API is involved, so there is **no runtime version gate** (applies to workers on any runtime — the checkpoint proxy is runtime-agnostic).
- Split out of the workspace-files PR (`#1208`) per review, to keep that PR focused on the storage/authorization feature.

---

## 摘要

worker checkpoint 代理（#1186）的 scoped 调用方检查把调用方团队与 `findTeamMember` 的**第二个返回值（成员/worker 名）**而非**团队名**做比较，导致 `TeamMatches` 恒为 false：所有团队 leader / L2 人类读自己团队 worker 的 checkpoints 一律 `404`——#1186 文档承诺的访问路径对目标角色实际不工作。跨团队调用方同样拿 `404`，而原测试套件只断言跨团队 `404`（在 bug 存在时也"恰好"通过），因此从未暴露。

修复：改与第一个返回值（Team CR 名）比较——与 `ResourceHandler.GetWorker` 同款链路。全量审计 6 个 `findTeamMember` 调用点，仅此处误用成员名返回值。行为变化对 in-scope 调用方纯增益（从错误的 `404` 变为文档承诺的 `200`），跨团队/未知调用方不变（`404`，W8 防探测保持）。

新增回归测试 `TestCheckpoint_L2HumanInScopeAllowed`。纯 controller 侧授权逻辑，不涉及 worker app API，无 runtime 版本门。按 review 要求从 #1208 拆出，保持该 PR 聚焦。
