### PR TITLE
fix(copaw): pin mcp below 2.0.0 in copaw-worker

### DIFF
--- a/copaw/pyproject.toml
+++ b/copaw/pyproject.toml
@@ -11,6 +11,12 @@ license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
     "copaw==1.0.2",
+    # mcp 2.0.0 renamed the client entrypoint
+    # `streamablehttp_client` -> `streamable_http_client` (breaking).
+    # copaw 1.0.2 imports the legacy name at worker startup, so the
+    # copaw worker crashes with ImportError when pip resolves mcp 2.x
+    # (agentscope 1.0.18 only requires mcp>=1.13). Cap at the 1.x line.
+    "mcp>=1.13,<2.0.0",
     "matrix-nio[e2e]>=0.24.0",
     "markdown-it-py>=3.0",
     "linkify-it-py>=2.0",


### PR DESCRIPTION
## What

Adds one constraint to `copaw-worker` dependencies (`copaw/pyproject.toml`):

```toml
"mcp>=1.13,<2.0.0",
```

## Why

- The MCP Python SDK renamed its client entrypoint in **2.0.0** (2026-07-27):
  `mcp.client.streamable_http.streamablehttp_client` → `streamable_http_client` (breaking rename;
  verified against the published `mcp-2.1.1` wheel source).
- `copaw 1.0.2` (PyPI) still imports the legacy name unconditionally at worker startup
  (app MCP client module, line 9: `from mcp.client.streamable_http import streamablehttp_client`).
- The copaw-worker dependency chain declares mcp **without an upper cap**:
  `copaw-worker 1.0.3 → copaw 1.0.2 → agentscope 1.0.18 → mcp>=1.13`.
- Since **mcp 2.1.1** was published (2026-08-25), any fresh image build resolves mcp 2.1.1,
  so every CoPaw worker container crashes at startup:
  `ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'`
  (container exits 1 within ~4s).

## Evidence (CI, 2026-09-01)

- copaw-worker build log:
  `Collecting mcp>=1.13 (from agentscope==1.0.18->copaw==1.0.2->copaw-worker==1.0.3)`
  → `Downloading mcp-2.1.1-py3-none-any.whl`.
- Every SHARD_C shard (openclaw/copaw/qwenpaw manager × copaw/hermes/qwenpaw worker) fails the
  copaw→qwenpaw migration test: `Unable to create CoPaw runtime state` + 3 cascading assertions
  (state not persisted / not active / incomplete); the copaw/copaw shard additionally loses the
  team lifecycle tests (workers run the default copaw runtime → crash loop).
- Reproduced locally with the same resolver: `pip install --dry-run copaw==1.0.2`
  → **mcp-2.1.1**; with the added cap → **mcp-1.29.1**.
- Control group (unaffected): the qwenpaw worker image pins `mcp<2.0.0` via
  `agentscope 2.0.4.post1` (resolves 1.29.1); manager-qwenpaw uses the same chain;
  openclaw/hermes workers do not import the legacy name.

## Fix

A single dependency line. pip intersects it with agentscope's `mcp>=1.13`, so resolution
returns 1.29.1 (the last 1.x line — the version CI has been green on). The constraint is in
copaw-worker itself, so it covers **both venvs** of the copaw-worker image (standard = copaw
from PyPI, lite = GitHub fork).

No code changes; no behavior change for correctly-running workers.

## Test plan

- CI `build-images (copaw-worker)` resolves `mcp 1.29.1`.
- SHARD_C copaw→qwenpaw migration tests and copaw-runtime team tests go green again.
- Re-runs of PRs whose only red job is SHARD_C should pass once this lands.

---


## 改了什么

`copaw-worker` 依赖（`copaw/pyproject.toml`）加一行上限：

```toml
"mcp>=1.13,<2.0.0",
```

## 为什么

- MCP Python SDK 在 **2.0.0**（2026-07-27）把客户端入口改名（breaking）：
  `mcp.client.streamable_http.streamablehttp_client` → `streamable_http_client`
  （已对照发布的 `mcp-2.1.1` wheel 源码验证）。
- `copaw 1.0.2`（PyPI）启动时仍无条件 import 旧名（应用 MCP 客户端模块第 9 行）。
- copaw-worker 依赖链对 mcp **没有上限**：
  `copaw-worker 1.0.3 → copaw 1.0.2 → agentscope 1.0.18 → mcp>=1.13`。
- **mcp 2.1.1**（2026-08-25 发布）之后，任何新构建都解析到 2.1.1，
  导致所有 CoPaw worker 容器启动即崩：
  `ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'`
  （容器 ~4 秒内 exit 1）。

## 证据（CI，2026-09-01）

- copaw-worker 构建日志：`Collecting mcp>=1.13 (from agentscope==1.0.18->copaw==1.0.2->copaw-worker==1.0.3)`
  → `Downloading mcp-2.1.1-py3-none-any.whl`。
- 全部 4 个 SHARD_C shard（openclaw/copaw/qwenpaw × copaw/hermes/qwenpaw）的
  copaw→qwenpaw 迁移测试失败（`Unable to create CoPaw runtime state` + 3 条级联断言）；
  copaw/copaw shard 另挂团队生命周期测试（worker 默认 copaw runtime → 崩溃重启循环）。
- 本地用同一 resolver 复现：无上限 → **mcp-2.1.1**；加上限 → **mcp-1.29.1**。
- 对照组（不受影响）：qwenpaw worker 经 `agentscope 2.0.4.post1` pin `mcp<2.0.0`
  （解析 1.29.1）；manager-qwenpaw 同链；openclaw/hermes worker 不 import 旧名。

## 修复方式

一行依赖约束。pip 与 agentscope 的 `mcp>=1.13` 求交集 → 解析回 1.29.1
（1.x 末版，CI 一直绿的版本）。约束放在 copaw-worker 自身，
因此**同时覆盖镜像的两个 venv**（standard = PyPI copaw，lite = GitHub fork）。

无代码改动；对正常运行的 worker 无行为变化。

## 验证

- CI `build-images (copaw-worker)` 解析出 `mcp 1.29.1`。
- SHARD_C 迁移测试与 copaw-runtime 团队测试恢复绿。
- 本 PR 合并后，仅 SHARD_C 红的在飞 PR 重跑即可转绿。