### PR TITLE
fix(matrix): prevent inbound callbacks from stalling sync

### DIFF
--- a/plugins/agentteams-matrix-channel/agentteams_matrix/channel.py
+++ b/plugins/agentteams-matrix-channel/agentteams_matrix/channel.py
@@ -86,6 +86,8 @@ TYPING_SERVER_TIMEOUT_MS = 30000
 TYPING_RENEWAL_INTERVAL_S = 25
 TYPING_MAX_DURATION_S = 120
 DM_CACHE_TTL_MS = 30_000
+DM_MEMBERSHIP_TIMEOUT_S = 5.0
+MATRIX_EVENT_CALLBACK_TIMEOUT_S = 120.0
 TASK_ROOM_CACHE_TTL_MS = 30_000
 MATRIX_EVENT_PROTOCOL_LIMIT_BYTES = 64 * 1024
 MATRIX_TEXT_EVENT_SAFE_BYTES = (MATRIX_EVENT_PROTOCOL_LIMIT_BYTES * 3) // 4
@@ -409,6 +411,7 @@ class AgentTeamsMatrixChannel(BaseChannel):
         self._client: Optional[AsyncClient] = None
         self._user_id: Optional[str] = None
         self._sync_task: Optional[asyncio.Task] = None
+        self._callback_tasks: set[asyncio.Task[Any]] = set()
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._room_histories: Dict[str, List[HistoryEntry]] = {}
         self._dm_room_cache: Dict[str, Dict[str, Any]] = {}
@@ -790,13 +793,93 @@ class AgentTeamsMatrixChannel(BaseChannel):
         logger.error("MatrixChannel: token login failed component=matrix response_type=%s", type(whoami).__name__)
         return False
 
+    def _schedule_event_callback(
+        self,
+        callback: Callable[[MatrixRoom, Any], Any],
+        room: MatrixRoom,
+        event: Any,
+    ) -> None:
+        """Schedule a room callback without blocking matrix-nio sync.
+
+        matrix-nio awaits event callbacks serially while handling a sync
+        response.  Matrix metadata and UX calls in the handlers are allowed
+        to use the network, so run them independently and keep their failures
+        visible instead of letting one callback stall all later events.
+        """
+        task = asyncio.create_task(
+            self._run_event_callback(callback, room, event),
+            name=(
+                "matrix-event-"
+                f"{getattr(callback, '__name__', 'callback')}-"
+                f"{str(getattr(event, 'event_id', ''))[:16]}"
+            ),
+        )
+        self._callback_tasks.add(task)
+        task.add_done_callback(self._callback_tasks.discard)
+
+    async def _run_event_callback(
+        self,
+        callback: Callable[[MatrixRoom, Any], Any],
+        room: MatrixRoom,
+        event: Any,
+    ) -> None:
+        event_id = str(getattr(event, "event_id", "") or "")
+        try:
+            await asyncio.wait_for(
+                callback(room, event),
+                timeout=MATRIX_EVENT_CALLBACK_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                "MatrixChannel: event callback timed out component=matrix "
+                "callback=%s event_id=%s sender=%s timeout_s=%s",
+                getattr(callback, "__name__", "callback"),
+                event_id,
+                getattr(event, "sender", ""),
+                MATRIX_EVENT_CALLBACK_TIMEOUT_S,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "MatrixChannel: event callback failed component=matrix "
+                "callback=%s event_id=%s sender=%s",
+                getattr(callback, "__name__", "callback"),
+                event_id,
+                getattr(event, "sender", ""),
+            )
+
+    def _schedule_room_event(self, room: MatrixRoom, event: Any) -> None:
+        self._schedule_event_callback(self._on_room_event, room, event)
+
+    def _schedule_room_media_event(
+        self,
+        room: MatrixRoom,
+        event: Any,
+    ) -> None:
+        self._schedule_event_callback(self._on_room_media_event, room, event)
+
+    def _schedule_room_encrypted_media_event(
+        self,
+        room: MatrixRoom,
+        event: Any,
+    ) -> None:
+        self._schedule_event_callback(
+            self._on_room_encrypted_media_event,
+            room,
+            event,
+        )
+
+    def _schedule_megolm_event(self, room: MatrixRoom, event: Any) -> None:
+        self._schedule_event_callback(self._on_megolm_event, room, event)
+
     def _register_plain_room_callbacks(self) -> None:
         self._client.add_event_callback(
-            self._on_room_event,
+            self._schedule_room_event,
             (RoomMessageText,),
         )
         self._client.add_event_callback(
-            self._on_room_media_event,
+            self._schedule_room_media_event,
             (
                 RoomMessageImage,
                 RoomMessageFile,
@@ -820,7 +903,7 @@ class AgentTeamsMatrixChannel(BaseChannel):
         # Encrypted media events (decrypted by nio, delivered as
         # RoomEncrypted* types)
         self._client.add_event_callback(
-            self._on_room_encrypted_media_event,
+            self._schedule_room_encrypted_media_event,
             (
                 RoomEncryptedImage,
                 RoomEncryptedAudio,
@@ -830,7 +913,7 @@ class AgentTeamsMatrixChannel(BaseChannel):
         )
         # Undecryptable events (missing session key)
         self._client.add_event_callback(
-            self._on_megolm_event,
+            self._schedule_megolm_event,
             (MegolmEvent,),
         )
         self._client.add_to_device_callback(
@@ -908,6 +991,12 @@ class AgentTeamsMatrixChannel(BaseChannel):
                 await self._sync_task
             except asyncio.CancelledError:
                 logger.debug("MatrixChannel: sync task cancelled during stop component=matrix")
+        if self._callback_tasks:
+            callback_tasks = tuple(self._callback_tasks)
+            for task in callback_tasks:
+                task.cancel()
+            await asyncio.gather(*callback_tasks, return_exceptions=True)
+            self._callback_tasks.clear()
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None
@@ -2585,7 +2674,10 @@ class AgentTeamsMatrixChannel(BaseChannel):
 
         # Fetch from Matrix API
         try:
-            resp = await self._client.joined_members(room_id)
+            resp = await asyncio.wait_for(
+                self._client.joined_members(room_id),
+                timeout=DM_MEMBERSHIP_TIMEOUT_S,
+            )
             if isinstance(resp, JoinedMembersResponse):
                 members = [m.user_id for m in resp.members]
                 # Update cache
@@ -2714,10 +2806,6 @@ class AgentTeamsMatrixChannel(BaseChannel):
                 )
                 return
 
-        # Mark as read + start typing immediately so the sender sees feedback
-        await self._send_read_receipt(room_id, event.event_id)
-        await self._send_typing(room_id, True)
-
         # Strip leading @mention so slash commands and NO_REPLY are detected
         # regardless of room type (group or DM).
         command_text = text
@@ -2806,6 +2894,11 @@ class AgentTeamsMatrixChannel(BaseChannel):
             self._enqueue(payload)
             if not is_dm and not is_thread_event:
                 self._clear_history(room_id)
+
+        # These are best-effort UX operations.  Enqueue first so a slow
+        # homeserver cannot prevent an accepted message from reaching QwenPaw.
+        await self._send_read_receipt(room_id, event.event_id)
+        await self._send_typing(room_id, True)
 
     # ------------------------------------------------------------------
     # Incoming message handling — media (image / file / audio / video)

--- a/plugins/agentteams-matrix-channel/agentteams_matrix/channel.py
+++ b/plugins/agentteams-matrix-channel/agentteams_matrix/channel.py
@@ -412,7 +412,9 @@ class AgentTeamsMatrixChannel(BaseChannel):
         self._user_id: Optional[str] = None
         self._sync_task: Optional[asyncio.Task] = None
         self._callback_tasks: set[asyncio.Task[Any]] = set()
+        self._room_callback_locks: Dict[str, asyncio.Lock] = {}
         self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._typing_locks: Dict[str, asyncio.Lock] = {}
         self._room_histories: Dict[str, List[HistoryEntry]] = {}
         self._dm_room_cache: Dict[str, Dict[str, Any]] = {}
         self._teamharness_task_room_cache: Dict[str, Dict[str, Any]] = {}
@@ -817,6 +819,14 @@ class AgentTeamsMatrixChannel(BaseChannel):
         self._callback_tasks.add(task)
         task.add_done_callback(self._callback_tasks.discard)
 
+    def _get_room_callback_lock(self, room_id: str) -> asyncio.Lock:
+        """Return the lock that serializes callbacks for one Matrix room."""
+        locks = getattr(self, "_room_callback_locks", None)
+        if locks is None:
+            locks = {}
+            self._room_callback_locks = locks
+        return locks.setdefault(room_id, asyncio.Lock())
+
     async def _run_event_callback(
         self,
         callback: Callable[[MatrixRoom, Any], Any],
@@ -824,11 +834,16 @@ class AgentTeamsMatrixChannel(BaseChannel):
         event: Any,
     ) -> None:
         event_id = str(getattr(event, "event_id", "") or "")
+        room_id = str(getattr(room, "room_id", "") or "")
         try:
-            await asyncio.wait_for(
-                callback(room, event),
-                timeout=MATRIX_EVENT_CALLBACK_TIMEOUT_S,
-            )
+            # Keep callbacks for one room ordered because handlers share
+            # room history and typing state.  Callbacks for other rooms can
+            # still make progress while this one waits or performs I/O.
+            async with self._get_room_callback_lock(room_id):
+                await asyncio.wait_for(
+                    callback(room, event),
+                    timeout=MATRIX_EVENT_CALLBACK_TIMEOUT_S,
+                )
         except asyncio.TimeoutError:
             logger.error(
                 "MatrixChannel: event callback timed out component=matrix "
@@ -997,6 +1012,15 @@ class AgentTeamsMatrixChannel(BaseChannel):
                 task.cancel()
             await asyncio.gather(*callback_tasks, return_exceptions=True)
             self._callback_tasks.clear()
+        self._room_callback_locks.clear()
+        if self._typing_tasks:
+            typing_tasks = tuple(self._typing_tasks.values())
+            for task in typing_tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*typing_tasks, return_exceptions=True)
+            self._typing_tasks.clear()
+        self._typing_locks.clear()
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None
@@ -3102,27 +3126,34 @@ class AgentTeamsMatrixChannel(BaseChannel):
         """
         if not self._client:
             return
-        # Cancel any existing renewal task for this room
-        existing = self._typing_tasks.pop(room_id, None)
-        if existing and not existing.done():
-            existing.cancel()
-        try:
-            await self._client.room_typing(
-                room_id,
-                typing_state=typing,
-                timeout=timeout,
-            )
-        except Exception as exc:
-            logger.debug(
-                "MatrixChannel: typing indicator failed for %s: %s",
-                room_id,
-                exc,
-            )
-        # Start renewal loop if turning on
-        if typing:
-            self._typing_tasks[room_id] = asyncio.create_task(
-                self._typing_renewal_loop(room_id, timeout),
-            )
+        locks = getattr(self, "_typing_locks", None)
+        if locks is None:
+            locks = {}
+            self._typing_locks = locks
+        async with locks.setdefault(room_id, asyncio.Lock()):
+            if not self._client:
+                return
+            # Cancel any existing renewal task for this room
+            existing = self._typing_tasks.pop(room_id, None)
+            if existing and not existing.done():
+                existing.cancel()
+            try:
+                await self._client.room_typing(
+                    room_id,
+                    typing_state=typing,
+                    timeout=timeout,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "MatrixChannel: typing indicator failed for %s: %s",
+                    room_id,
+                    exc,
+                )
+            # Start renewal loop if turning on
+            if typing:
+                self._typing_tasks[room_id] = asyncio.create_task(
+                    self._typing_renewal_loop(room_id, timeout),
+                )
 
     async def _typing_renewal_loop(
         self,
@@ -3166,7 +3197,9 @@ class AgentTeamsMatrixChannel(BaseChannel):
                         room_id,
                         exc,
                     )
-            self._typing_tasks.pop(room_id, None)
+            current_task = asyncio.current_task()
+            if self._typing_tasks.get(room_id) is current_task:
+                self._typing_tasks.pop(room_id, None)
 
     # ------------------------------------------------------------------
     # build_agent_request_from_native (BaseChannel protocol)

--- a/qwenpaw/tests/test_matrix_overlay.py
+++ b/qwenpaw/tests/test_matrix_overlay.py
@@ -63,6 +63,63 @@ def test_matrix_overlay_supports_streaming_reasoning_hooks() -> None:
     assert "async def on_streaming_end" in source
 
 
+def test_matrix_event_callback_is_scheduled_without_blocking_sync() -> None:
+    module = _load_overlay_module()
+    channel = module.AgentTeamsMatrixChannel.__new__(
+        module.AgentTeamsMatrixChannel,
+    )
+    channel._callback_tasks = set()
+    started = asyncio.Event()
+    released = asyncio.Event()
+    finished = asyncio.Event()
+    room = SimpleNamespace(room_id="!room:hs.local")
+    event = SimpleNamespace(event_id="$event", sender="@worker:hs.local")
+
+    async def _blocked_callback(_room, _event):
+        started.set()
+        await released.wait()
+        finished.set()
+
+    async def _run() -> None:
+        channel._schedule_event_callback(_blocked_callback, room, event)
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert len(channel._callback_tasks) == 1
+
+        released.set()
+        await asyncio.wait_for(finished.wait(), timeout=1)
+        await asyncio.sleep(0)
+        assert not channel._callback_tasks
+
+    asyncio.run(_run())
+
+
+def test_matrix_event_callback_timeout_is_logged_and_cleaned_up(caplog) -> None:
+    module = _load_overlay_module()
+    module.MATRIX_EVENT_CALLBACK_TIMEOUT_S = 0.01
+    channel = module.AgentTeamsMatrixChannel.__new__(
+        module.AgentTeamsMatrixChannel,
+    )
+    channel._callback_tasks = set()
+    room = SimpleNamespace(room_id="!room:hs.local")
+    event = SimpleNamespace(event_id="$event", sender="@worker:hs.local")
+
+    async def _blocked_callback(_room, _event):
+        await asyncio.Event().wait()
+
+    async def _run() -> None:
+        channel._schedule_event_callback(_blocked_callback, room, event)
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+            if not channel._callback_tasks:
+                return
+        raise AssertionError("timed-out callback task was not cleaned up")
+
+    with caplog.at_level("ERROR"):
+        asyncio.run(_run())
+
+    assert "event callback timed out" in caplog.text
+
+
 def _install_module(name: str, **attrs):
     module = types.ModuleType(name)
     module.__dict__.update(attrs)
@@ -1134,6 +1191,33 @@ def test_matrix_ordinary_own_message_is_skipped() -> None:
     )
 
     assert channel.enqueued == []
+
+
+def test_matrix_text_message_is_enqueued_before_slow_receipt() -> None:
+    channel = _make_inbound_channel()
+    started = asyncio.Event()
+    released = asyncio.Event()
+
+    async def _blocked_read_receipt(_room_id, _event_id):
+        started.set()
+        await released.wait()
+
+    channel._send_read_receipt = _blocked_read_receipt
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            channel._on_room_event(
+                _FakeInboundRoom(),
+                _matrix_event("copywriting-assistant: process this", mentioned=True),
+            ),
+        )
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert len(channel.enqueued) == 1
+
+        released.set()
+        await task
+
+    asyncio.run(_run())
 
 
 def test_matrix_teamharness_self_trigger_bypasses_own_skip_and_mention_gate() -> None:

--- a/qwenpaw/tests/test_matrix_overlay.py
+++ b/qwenpaw/tests/test_matrix_overlay.py
@@ -69,6 +69,7 @@ def test_matrix_event_callback_is_scheduled_without_blocking_sync() -> None:
         module.AgentTeamsMatrixChannel,
     )
     channel._callback_tasks = set()
+    channel._room_callback_locks = {}
     started = asyncio.Event()
     released = asyncio.Event()
     finished = asyncio.Event()
@@ -93,13 +94,17 @@ def test_matrix_event_callback_is_scheduled_without_blocking_sync() -> None:
     asyncio.run(_run())
 
 
-def test_matrix_event_callback_timeout_is_logged_and_cleaned_up(caplog) -> None:
+def test_matrix_event_callback_timeout_is_logged_and_cleaned_up(
+    caplog,
+    monkeypatch,
+) -> None:
     module = _load_overlay_module()
-    module.MATRIX_EVENT_CALLBACK_TIMEOUT_S = 0.01
+    monkeypatch.setattr(module, "MATRIX_EVENT_CALLBACK_TIMEOUT_S", 0.01)
     channel = module.AgentTeamsMatrixChannel.__new__(
         module.AgentTeamsMatrixChannel,
     )
     channel._callback_tasks = set()
+    channel._room_callback_locks = {}
     room = SimpleNamespace(room_id="!room:hs.local")
     event = SimpleNamespace(event_id="$event", sender="@worker:hs.local")
 
@@ -118,6 +123,97 @@ def test_matrix_event_callback_timeout_is_logged_and_cleaned_up(caplog) -> None:
         asyncio.run(_run())
 
     assert "event callback timed out" in caplog.text
+
+
+def test_matrix_event_callbacks_are_serialized_per_room_but_not_globally() -> None:
+    module = _load_overlay_module()
+    channel = module.AgentTeamsMatrixChannel.__new__(
+        module.AgentTeamsMatrixChannel,
+    )
+    channel._callback_tasks = set()
+    channel._room_callback_locks = {}
+    room_a = SimpleNamespace(room_id="!room-a:hs.local")
+    room_b = SimpleNamespace(room_id="!room-b:hs.local")
+    event_a1 = SimpleNamespace(event_id="$event-a1", sender="@worker:hs.local")
+    event_a2 = SimpleNamespace(event_id="$event-a2", sender="@worker:hs.local")
+    event_b = SimpleNamespace(event_id="$event-b", sender="@worker:hs.local")
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    other_room_started = asyncio.Event()
+    release = asyncio.Event()
+    order = []
+
+    async def _first_callback(_room, _event):
+        order.append("first")
+        first_started.set()
+        await release.wait()
+
+    async def _second_callback(_room, _event):
+        order.append("second")
+        second_started.set()
+
+    async def _other_room_callback(_room, _event):
+        order.append("other-room")
+        other_room_started.set()
+        await release.wait()
+
+    async def _run() -> None:
+        channel._schedule_event_callback(_first_callback, room_a, event_a1)
+        channel._schedule_event_callback(_second_callback, room_a, event_a2)
+        channel._schedule_event_callback(_other_room_callback, room_b, event_b)
+        callback_tasks = tuple(channel._callback_tasks)
+
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        await asyncio.wait_for(other_room_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+        assert not second_started.is_set()
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*callback_tasks), timeout=1)
+        assert second_started.is_set()
+        assert order.index("first") < order.index("second")
+        assert not channel._callback_tasks
+
+    asyncio.run(_run())
+
+
+def test_matrix_stop_cancels_and_drains_event_callbacks() -> None:
+    module = _load_overlay_module()
+    channel = module.AgentTeamsMatrixChannel.__new__(
+        module.AgentTeamsMatrixChannel,
+    )
+    channel._callback_tasks = set()
+    channel._room_callback_locks = {}
+    channel._typing_tasks = {}
+    channel._typing_locks = {}
+    channel._sync_task = None
+    channel._http_client = None
+
+    async def _close_client():
+        return None
+
+    channel._client = SimpleNamespace(close=_close_client)
+    room = SimpleNamespace(room_id="!room:hs.local")
+    event = SimpleNamespace(event_id="$event", sender="@worker:hs.local")
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _blocked_callback(_room, _event):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def _run() -> None:
+        channel._schedule_event_callback(_blocked_callback, room, event)
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await channel.stop()
+        assert cancelled.is_set()
+        assert not channel._callback_tasks
+
+    asyncio.run(_run())
 
 
 def _install_module(name: str, **attrs):


### PR DESCRIPTION
## Summary

- Run Matrix room event handlers in tracked background tasks so a slow handler cannot block matrix-nio's sync loop.
- Bound joined-member lookup and the overall callback, with error and timeout logs.
- Enqueue accepted text messages before best-effort read-receipt and typing operations.
- Cancel outstanding callback tasks during channel shutdown.

## Validation

- `python -m pytest qwenpaw/tests/test_matrix_overlay.py qwenpaw/tests/test_matrix_plugin.py qwenpaw/tests/test_matrix_plugin_edit_mentions.py -q` -> 44 passed
- `python -m compileall -q plugins/agentteams-matrix-channel qwenpaw/tests/test_matrix_overlay.py`
- `git diff --check`
- Full `qwenpaw/tests` run: 173 passed, 25 unrelated Windows-environment failures in existing package update, symlink, `mc`, ACP dependency, and workflow-assertion tests.

Fixes #672
