### PR TITLE
fix(copaw): configure static MinIO alias in Kubernetes

### DIFF
--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -303,9 +303,14 @@ class FileSync:
 
         Cloud mode (RRSA/STS): refresh credentials before every mc batch
         via the shared shell function (lazy, no-op when token is valid).
-        Local mode: set mc alias once with static credentials.
+        Kubernetes uses an existing MC_HOST alias for OSS, or sets the alias
+        once with static credentials for MinIO.
+        Local mode also sets the alias once with static credentials.
         """
         runtime = os.environ.get("AGENTTEAMS_RUNTIME", "<unset>")
+        storage_provider = (
+            os.environ.get("AGENTTEAMS_STORAGE_PROVIDER", "").strip().lower()
+        )
         mc_host_set = bool(os.environ.get(f"MC_HOST_{_MC_ALIAS}"))
         controller_url = os.environ.get("AGENTTEAMS_CONTROLLER_URL", "<unset>")
         logger.info(
@@ -322,9 +327,17 @@ class FileSync:
             controller_url,
         )
         if self._k8s_mode:
-            logger.info("_ensure_alias: k8s mode, skipping mc alias set (mc-wrapper handles credentials)")
-            self._alias_set = True
-            return
+            if mc_host_set:
+                logger.info(
+                    "_ensure_alias: k8s mode, MC_HOST_%s already set, skipping mc alias set",
+                    _MC_ALIAS,
+                )
+                self._alias_set = True
+                return
+            if storage_provider == "oss":
+                raise RuntimeError(
+                    f"OSS storage requires controller-issued MC_HOST_{_MC_ALIAS} credentials"
+                )
         if self._cloud_mode:
             logger.info("_ensure_alias: credential path=sts, refreshing MC_HOST_%s", _MC_ALIAS)
             self._refresh_cloud_credentials()

--- a/copaw/tests/test_worker_sync.py
+++ b/copaw/tests/test_worker_sync.py
@@ -3,17 +3,14 @@
 import logging
 import subprocess
 
+import pytest
+
 from copaw_worker import sync
 from copaw_worker.sync import FileSync
 
 
-def test_ensure_alias_skips_static_alias_in_k8s_mode(monkeypatch, tmp_path):
-    calls = []
-
-    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
-    monkeypatch.setattr(sync, "_mc", lambda *args, **_kwargs: calls.append(args))
-
-    fs = FileSync(
+def _file_sync(tmp_path):
+    return FileSync(
         endpoint="minio:9000",
         access_key="tt",
         secret_key="secret",
@@ -21,6 +18,69 @@ def test_ensure_alias_skips_static_alias_in_k8s_mode(monkeypatch, tmp_path):
         worker_name="tt",
         local_dir=tmp_path,
     )
+
+
+@pytest.mark.parametrize("storage_provider", ["minio", None])
+def test_ensure_alias_sets_static_alias_for_minio_in_k8s_mode(
+    monkeypatch, tmp_path, storage_provider
+):
+    calls = []
+
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+    if storage_provider is None:
+        monkeypatch.delenv("AGENTTEAMS_STORAGE_PROVIDER", raising=False)
+    else:
+        monkeypatch.setenv("AGENTTEAMS_STORAGE_PROVIDER", storage_provider)
+    monkeypatch.delenv(f"MC_HOST_{sync._MC_ALIAS}", raising=False)
+    monkeypatch.setattr(sync, "_mc", lambda *args, **_kwargs: calls.append(args))
+
+    fs = _file_sync(tmp_path)
+
+    fs._ensure_alias()
+
+    assert fs._alias_set is True
+    assert calls == [
+        (
+            "alias",
+            "set",
+            sync._MC_ALIAS,
+            "http://minio:9000",
+            "tt",
+            "secret",
+        )
+    ]
+
+
+def test_ensure_alias_requires_mc_host_for_oss_in_k8s_mode(monkeypatch, tmp_path):
+    calls = []
+
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PROVIDER", "oss")
+    monkeypatch.delenv(f"MC_HOST_{sync._MC_ALIAS}", raising=False)
+    monkeypatch.setattr(sync, "_mc", lambda *args, **_kwargs: calls.append(args))
+
+    fs = _file_sync(tmp_path)
+
+    with pytest.raises(RuntimeError, match=f"MC_HOST_{sync._MC_ALIAS}"):
+        fs._ensure_alias()
+
+    assert calls == []
+
+
+def test_ensure_alias_uses_existing_mc_host_for_oss_in_k8s_mode(
+    monkeypatch, tmp_path
+):
+    calls = []
+
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PROVIDER", "oss")
+    monkeypatch.setenv(
+        f"MC_HOST_{sync._MC_ALIAS}",
+        "https://access:secret:token@oss-cn-hangzhou.aliyuncs.com",
+    )
+    monkeypatch.setattr(sync, "_mc", lambda *args, **_kwargs: calls.append(args))
+
+    fs = _file_sync(tmp_path)
 
     fs._ensure_alias()
 


### PR DESCRIPTION
## Summary

- configure the static `mc` alias for Kubernetes Workers using MinIO when no `MC_HOST_<alias>` is present
- preserve the controller-issued `MC_HOST_<alias>` path for OSS
- fail explicitly when `storage.provider=oss` has no controller-issued credentials instead of falling back to placeholder static credentials
- retain the static fallback when the provider is absent for mixed-version compatibility

## Root cause

`FileSync._ensure_alias()` previously skipped `mc alias set` for every Kubernetes Worker because it assumed `mc-wrapper` configured the alias. The wrapper only provisions `MC_HOST_agentteams` for OSS/STS; it is intentionally a pass-through for MinIO. Therefore default Kubernetes + MinIO Workers had neither an `MC_HOST_agentteams` alias nor a static alias, and `mc mirror agentteams/...` resolved its source as a local filesystem path.

The fix makes the decision provider-aware:

- existing `MC_HOST_agentteams`: use the controller-issued alias (OSS/STS)
- `provider=oss` without `MC_HOST_agentteams`: fail explicitly because the credential contract is broken
- MinIO, or a missing provider from a mixed-version controller: configure the existing static endpoint/access-key/secret alias

## Reproduction

On `origin/main` at `eeaab643`, both the new regression test and an isolated real-MinIO container test reproduce the issue. The released `v1.2.3` image fails with:

```text
Unable to stat source `agentteams/agentteams-storage/agents/smoke/`.
Requested path `/root/.copaw-worker/agentteams/agentteams-storage/agents/smoke/` not found.
```

## Verification

- `python -m pytest tests/test_worker_sync.py tests/test_copaw_worker_entrypoint.py -q` — 9 passed
- `python -m compileall -q src/copaw_worker`
- `git diff --check origin/main...HEAD`
- isolated container test against MinIO `RELEASE.2025-04-22T22-12-26Z`:
  - released `v1.2.3`: reproduced the local-path failure above
  - patched image, Kubernetes + MinIO: initial mirror succeeded; `.copaw/config.json`, `.copaw/providers.json`, and `.copaw/workspaces/default/agent.json` were materialized; a runtime session file was uploaded and read back from MinIO
  - patched image, Kubernetes + existing `MC_HOST_agentteams`: the same mirror, bridge, and runtime-persistence flow succeeded, covering the OSS/STS alias boundary
  - an absent `shared/` prefix remained a non-fatal warning as designed and did not block initialization

The unfiltered local CoPaw suite was also attempted, but it is not a clean baseline in this environment: 87 unrelated failures occur across bridge, Matrix, health, and other existing test areas. The touched sync and credential-entrypoint scopes pass independently.

This is a current-`main`, provider-aware, tested alternative to #901, which remains blocked on the missing tests and OSS credential boundary.

Fixes #957
Fixes #1226

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- configure the static `mc` alias for Kubernetes Workers using MinIO when no `MC_HOST_<alias>` is present
- preserve the controller-issued `MC_HOST_<alias>` path for OSS
- fail explicitly when `storage.provider=oss` has no controller-issued credentials instead of falling back to placeholder static credentials
- retain the static fallback when the provider is absent for mixed-version compatibility

## Root cause

`FileSync._ensure_alias()` previously skipped `mc alias set` for every Kubernetes Worker because it assumed `mc-wrapper` configured the alias. The wrapper only provisions `MC_HOST_agentteams` for OSS/STS; it is intentionally a pass-through for MinIO. Therefore default Kubernetes + MinIO Workers had neither an `MC_HOST_agentteams` alias nor a static alias, and `mc mirror agentteams/...` resolved its source as a local filesystem path.

The fix makes the decision provider-aware:

- existing `MC_HOST_agentteams`: use the controller-issued alias (OSS/STS)
- `provider=oss` without `MC_HOST_agentteams`: fail explicitly because the credential contract is broken
- MinIO, or a missing provider from a mixed-version controller: configure the existing static endpoint/access-key/secret alias

## Reproduction

On `origin/main` at `eeaab643`, both the new regression test and an isolated real-MinIO container test reproduce the issue. The released `v1.2.3` image fails with:

```text
Unable to stat source `agentteams/agentteams-storage/agents/smoke/`.
Requested path `/root/.copaw-worker/agentteams/agentteams-storage/agents/smoke/` not found.
```

## Verification

- `python -m pytest tests/test_worker_sync.py tests/test_copaw_worker_entrypoint.py -q` — 9 passed
- `python -m compileall -q src/copaw_worker`
- `git diff --check origin/main...HEAD`
- isolated container test against MinIO `RELEASE.2025-04-22T22-12-26Z`:
- released `v1.2.3`: reproduced the local-path failure above
- patched image, Kubernetes + MinIO: initial mirror succeeded; `.copaw/config.json`, `.copaw/providers.json`, and `.copaw/workspaces/default/agent.json` were materialized; a runtime session file was uploaded and read back from MinIO
- patched image, Kubernetes + existing `MC_HOST_agentteams`: the same mirror, bridge, and runtime-persistence flow succeeded, covering the OSS/STS alias boundary
- an absent `shared/` prefix remained a non-fatal warning as designed and did not block initialization

The unfiltered local CoPaw suite was also attempted, but it is not a clean baseline in this environment: 87 unrelated failures occur across bridge, Matrix, health, and other existing test areas. The touched sync and credential-entrypoint scopes pass independently.

This is a current-`main`, provider-aware, tested alternative to #901, which remains blocked on the missing tests and OSS credential boundary.

Fixes #957
Fixes #1226
