### PR TITLE
fix(controller): allow clearing Manager model provider

### DIFF
--- a/agentteams-controller/cmd/agt/update.go
+++ b/agentteams-controller/cmd/agt/update.go
@@ -184,11 +184,12 @@ Create or update each Worker separately to configure its runtime fields.`,
 
 func updateManagerCmd() *cobra.Command {
 	var (
-		name    string
-		model   string
-		runtime string
-		image   string
-		soul    string
+		name          string
+		model         string
+		modelProvider string
+		runtime       string
+		image         string
+		soul          string
 	)
 
 	cmd := &cobra.Command{
@@ -197,6 +198,7 @@ func updateManagerCmd() *cobra.Command {
 		Long: `Update an existing Manager resource. Only specified fields are changed.
 
   agt update manager --name default --model claude-sonnet-4-6
+  agt update manager --name default --model qwen3.6-plus --model-provider=
   agt update manager --name default --image agentteams/agentteams-manager:v1.2.0
   To update CPU/memory resources, use a YAML manifest and pass it with 'agt apply -f manager.yaml'.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -206,6 +208,9 @@ func updateManagerCmd() *cobra.Command {
 
 			req := map[string]interface{}{}
 			setIfNotEmpty(req, "model", model)
+			if cmd.Flags().Changed("model-provider") {
+				req["modelProvider"] = modelProvider
+			}
 			setIfNotEmpty(req, "runtime", runtime)
 			setIfNotEmpty(req, "image", image)
 			setIfNotEmpty(req, "soul", soul)
@@ -226,6 +231,7 @@ func updateManagerCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "", "Manager name (required)")
 	cmd.Flags().StringVar(&model, "model", "", "LLM model ID")
+	cmd.Flags().StringVar(&modelProvider, "model-provider", "", "LLM provider name (empty clears the binding)")
 	cmd.Flags().StringVar(&runtime, "runtime", "", "Agent runtime (openclaw|copaw|hermes|openhuman)")
 	cmd.Flags().StringVar(&image, "image", "", "Container image override")
 	cmd.Flags().StringVar(&soul, "soul", "", "Manager SOUL.md content")

--- a/agentteams-controller/cmd/agt/update_test.go
+++ b/agentteams-controller/cmd/agt/update_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpdateManagerCanClearModelProvider(t *testing.T) {
+	var body map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/managers/default" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	t.Setenv("AGENTTEAMS_CONTROLLER_URL", server.URL)
+
+	cmd := updateManagerCmd()
+	cmd.SetArgs([]string{"--name", "default", "--model", "known-good-model", "--model-provider="})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute update manager: %v", err)
+	}
+
+	if got := body["model"]; got != "known-good-model" {
+		t.Fatalf("model=%v, want known-good-model", got)
+	}
+	provider, ok := body["modelProvider"]
+	if !ok {
+		t.Fatal("modelProvider is missing from request")
+	}
+	if provider != "" {
+		t.Fatalf("modelProvider=%v, want empty", provider)
+	}
+}

--- a/agentteams-controller/internal/server/resource_handler.go
+++ b/agentteams-controller/internal/server/resource_handler.go
@@ -694,8 +694,8 @@ func (h *ResourceHandler) UpdateManager(w http.ResponseWriter, r *http.Request) 
 		if req.Model != "" {
 			mgr.Spec.Model = req.Model
 		}
-		if req.ModelProvider != "" {
-			mgr.Spec.ModelProvider = req.ModelProvider
+		if req.ModelProvider != nil {
+			mgr.Spec.ModelProvider = *req.ModelProvider
 		}
 		if req.Runtime != "" {
 			mgr.Spec.Runtime = req.Runtime

--- a/agentteams-controller/internal/server/resource_handler_test.go
+++ b/agentteams-controller/internal/server/resource_handler_test.go
@@ -645,6 +645,41 @@ func TestCreateAndUpdateManagerPersistsModelProvider(t *testing.T) {
 	}
 }
 
+func TestUpdateManagerClearsModelProviderWhenExplicitlyEmpty(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	manager := &v1beta1.Manager{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "default"},
+		Spec: v1beta1.ManagerSpec{
+			Model:         "custom-model",
+			ModelProvider: "deleted-provider",
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(manager).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/managers/default", bytes.NewReader([]byte(`{
+		"model":"known-good-model",
+		"modelProvider":""
+	}`)))
+	updateReq.SetPathValue("name", "default")
+	updateRec := httptest.NewRecorder()
+	handler.UpdateManager(updateRec, updateReq)
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("expected update status %d, got %d: %s", http.StatusOK, updateRec.Code, updateRec.Body.String())
+	}
+
+	var updated v1beta1.Manager
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "default", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get updated manager: %v", err)
+	}
+	if updated.Spec.Model != "known-good-model" {
+		t.Fatalf("updated manager model=%q, want known-good-model", updated.Spec.Model)
+	}
+	if updated.Spec.ModelProvider != "" {
+		t.Fatalf("updated manager modelProvider=%q, want empty", updated.Spec.ModelProvider)
+	}
+}
+
 func TestCreateTeamRequiresExactlyOneLeaderReference(t *testing.T) {
 	scheme := newServerTestScheme(t)
 	leadOne := &v1beta1.Worker{ObjectMeta: metav1.ObjectMeta{Name: "lead-one", Namespace: "default"}}

--- a/agentteams-controller/internal/server/types.go
+++ b/agentteams-controller/internal/server/types.go
@@ -194,7 +194,7 @@ type CreateManagerRequest struct {
 
 type UpdateManagerRequest struct {
 	Model         string                             `json:"model,omitempty"`
-	ModelProvider string                             `json:"modelProvider,omitempty"`
+	ModelProvider *string                            `json:"modelProvider,omitempty"`
 	Runtime       string                             `json:"runtime,omitempty"`
 	Image         string                             `json:"image,omitempty"`
 	Soul          string                             `json:"soul,omitempty"`


### PR DESCRIPTION
## Summary

- distinguish an omitted `modelProvider` update from an explicitly empty value
- allow the Manager update API to clear a stale `spec.modelProvider` binding
- add `agt update manager --model-provider`, including `--model-provider=` for recovery
- cover both API and CLI behavior with regression tests

## Context

When a Manager has switched to a model from a newly added provider and that provider or route is later removed, the persisted provider binding cannot currently be cleared through the update API. The Manager continues reconciling/requesting against the unavailable provider after restart, leaving reinstall as the apparent recovery path.

This change makes the recovery operation explicit:

```shell
agt update manager --name default \
  --model <known-good-model> \
  --model-provider=
```

The pointer field in `UpdateManagerRequest` preserves PATCH semantics: an omitted field remains unchanged, while an explicitly empty value clears the binding.

The original report also says adding the provider causes an immediate chat error. It does not include the version, deployment mode, exact error, or logs, so this PR addresses the confirmed persistent recovery defect without claiming a cause for that separate initial failure.

## Verification

- rebased onto current `origin/main` (`eeaab643`)
- `go test ./...` from `agentteams-controller` — passed
- `git diff --check origin/main...HEAD` — passed

Related to #1224

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- distinguish an omitted `modelProvider` update from an explicitly empty value
- allow the Manager update API to clear a stale `spec.modelProvider` binding
- add `agt update manager --model-provider`, including `--model-provider=` for recovery
- cover both API and CLI behavior with regression tests

## Context

When a Manager has switched to a model from a newly added provider and that provider or route is later removed, the persisted provider binding cannot currently be cleared through the update API. The Manager continues reconciling/requesting against the unavailable provider after restart, leaving reinstall as the apparent recovery path.

This change makes the recovery operation explicit:

```shell
agt update manager --name default \
--model <known-good-model> \
--model-provider=
```

The pointer field in `UpdateManagerRequest` preserves PATCH semantics: an omitted field remains unchanged, while an explicitly empty value clears the binding.

The original report also says adding the provider causes an immediate chat error. It does not include the version, deployment mode, exact error, or logs, so this PR addresses the confirmed persistent recovery defect without claiming a cause for that separate initial failure.

## Verification

- rebased onto current `origin/main` (`eeaab643`)
- `go test ./...` from `agentteams-controller` — passed
- `git diff --check origin/main...HEAD` — passed

Related to #1224
